### PR TITLE
Remove other isinstance checks that prevented use of proxies

### DIFF
--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -130,11 +130,11 @@ def diff(input: Diffable, output: Diffable, ptr: Pointer = None) -> Tuple[List, 
         return [], []
     if ptr is None:
         ptr = Pointer()
-    if isinstance(input, list) and isinstance(output, list):
+    if hasattr(input, "append") and hasattr(output, "append"):  # list
         return diff_lists(input, output, ptr)
-    if isinstance(input, dict) and isinstance(output, dict):
+    if hasattr(input, "keys") and hasattr(output, "keys"):  # dict
         return diff_dicts(input, output, ptr)
-    if isinstance(input, set) and isinstance(output, set):
+    if hasattr(input, "add") and hasattr(output, "add"):  # set
         return diff_sets(input, output, ptr)
     return [{"op": "replace", "path": ptr, "value": output}], [
         {"op": "replace", "path": ptr, "value": input}

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -49,9 +49,9 @@ class Pointer:
         cursor = obj
         for key in self.tokens:
             parent = cursor
-            if isinstance(parent, set):
+            if hasattr(parent, "add"):  # set
                 break
-            if isinstance(parent, list):
+            if hasattr(parent, "append"):  # list
                 if key == "-":
                     break
             try:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -3,13 +3,41 @@ Tests that check that patchdiff apply and diff work
 on proxied objects.
 """
 from collections import UserDict, UserList
+from collections.abc import Set
 
 from patchdiff import apply, diff
+
+
+class SetProxy(Set):
+    """
+    Custom proxy class that works like UserDict and UserList by
+    storing the original data under the 'data' attribute.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.data = set(*args, **kwargs)
+
+    def __contains__(self, *args, **kwargs):
+        return self.data.__contains__(*args, **kwargs)
+
+    def __iter__(self, *args, **kwargs):
+        return self.data.__iter__(*args, **kwargs)
+
+    def __len__(self, *args, **kwargs):
+        return self.data.__len__(*args, **kwargs)
+
+    def __getattribute__(self, attr):
+        # Redirect __class__ to super() to make sure
+        # isinstance(obj, set) will fail
+        if attr in {"data", "_from_iterable", "__class__"}:
+            return super().__getattribute__(attr)
+        return self.data.__getattribute__(attr)
 
 
 def test_proxy_dict():
     data = {"foo": "bar"}
     obj = UserDict(data)
+    assert not isinstance(obj, dict)
 
     old = obj.copy()
     obj["foo"] = "baz"
@@ -26,12 +54,30 @@ def test_proxy_dict():
 def test_proxy_list():
     data = [1, 2]
     obj = UserList(data)
+    assert not isinstance(obj, list)
 
     old = obj.copy()
     obj[1] = 3
 
     assert old[1] == 2
     assert obj[1] == 3
+
+    ops, reverse_ops = diff(old, obj)
+
+    assert apply(old, ops) == obj
+    assert apply(obj, reverse_ops) == old
+
+
+def test_proxy_set():
+    data = {"a", "b"}
+    obj = SetProxy(data)
+    assert not isinstance(obj, set)
+
+    old = obj.copy()
+    obj.add("c")
+
+    assert "c" not in old
+    assert "c" in obj
 
     ops, reverse_ops = diff(old, obj)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,39 @@
+"""
+Tests that check that patchdiff apply and diff work
+on proxied objects.
+"""
+from collections import UserDict, UserList
+
+from patchdiff import apply, diff
+
+
+def test_proxy_dict():
+    data = {"foo": "bar"}
+    obj = UserDict(data)
+
+    old = obj.copy()
+    obj["foo"] = "baz"
+
+    assert old["foo"] == "bar"
+    assert obj["foo"] == "baz"
+
+    ops, reverse_ops = diff(old, obj)
+
+    assert apply(old, ops) == obj
+    assert apply(obj, reverse_ops) == old
+
+
+def test_proxy_list():
+    data = [1, 2]
+    obj = UserList(data)
+
+    old = obj.copy()
+    obj[1] = 3
+
+    assert old[1] == 2
+    assert obj[1] == 3
+
+    ops, reverse_ops = diff(old, obj)
+
+    assert apply(old, ops) == obj
+    assert apply(obj, reverse_ops) == old


### PR DESCRIPTION
This should really make it possible to generate and apply patches from/on proxies.