### PR TITLE
Fixes for (reverse) ops

### DIFF
--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -77,7 +77,7 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                 "op": "remove",
                 "path": ptr.append(op["idx"] + padding),
             }
-            return [ops + [full_op], padding - 1]
+            return [ops + [full_op], padding]
         else:
             replace_ptr = ptr.append(op["idx"] + padding)
             replace_ops, _ = diff(op["original"], op["value"], replace_ptr)

--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -1,4 +1,4 @@
-from functools import reduce
+from functools import partial, reduce
 from typing import Dict, List, Set, Tuple
 
 from .pointer import Pointer
@@ -17,7 +17,7 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                 if i > 0:
                     base = dist(i - 1, j)
                     op = {"op": "remove", "idx": i - 1}
-                    rop = {"op": "add", "idx": i - 1, "value": input[i - 1]}
+                    rop = {"op": "add", "idx": j - 1, "value": input[i - 1]}
                     paths.append(
                         {
                             "ops": base["ops"] + [op],
@@ -28,7 +28,7 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                 if j > 0:
                     base = dist(i, j - 1)
                     op = {"op": "add", "idx": i - 1, "value": output[j - 1]}
-                    rop = {"op": "remove", "idx": i - 1}
+                    rop = {"op": "remove", "idx": j - 1}
                     paths.append(
                         {
                             "ops": base["ops"] + [op],
@@ -46,7 +46,7 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                     }
                     rop = {
                         "op": "replace",
-                        "idx": i - 1,
+                        "idx": j - 1,
                         "original": output[j - 1],
                         "value": input[i - 1],
                     }
@@ -61,11 +61,11 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
             memory[(i, j)] = step
         return memory[(i, j)]
 
-    def pad(state, op):
+    def pad(state, op, target=None):
         ops, padding = state
         if op["op"] == "add":
             padded_idx = op["idx"] + 1 + padding
-            idx_token = padded_idx if padded_idx < len(input) + padding else "-"
+            idx_token = padded_idx if padded_idx < len(target) + padding else "-"
             full_op = {
                 "op": "add",
                 "path": ptr.append(idx_token),
@@ -84,8 +84,8 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
             return [ops + replace_ops, padding]
 
     solution = dist(len(input), len(output))
-    padded_ops, _ = reduce(pad, solution["ops"], [[], 0])
-    padded_rops, _ = reduce(pad, reversed(solution["rops"]), [[], 0])
+    padded_ops, _ = reduce(partial(pad, target=input), solution["ops"], [[], 0])
+    padded_rops, _ = reduce(partial(pad, target=output), solution["rops"], [[], 0])
 
     return padded_ops, padded_rops
 

--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -27,8 +27,8 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                     )
                 if j > 0:
                     base = dist(i, j - 1)
-                    op = {"op": "add", "idx": j - 1, "value": output[j - 1]}
-                    rop = {"op": "remove", "idx": j - 1}
+                    op = {"op": "add", "idx": i - 1, "value": output[j - 1]}
+                    rop = {"op": "remove", "idx": i - 1}
                     paths.append(
                         {
                             "ops": base["ops"] + [op],
@@ -77,7 +77,7 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
                 "op": "remove",
                 "path": ptr.append(op["idx"] + padding),
             }
-            return [ops + [full_op], padding]
+            return [ops + [full_op], padding - 1]
         else:
             replace_ptr = ptr.append(op["idx"] + padding)
             replace_ops, _ = diff(op["original"], op["value"], replace_ptr)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -53,3 +53,16 @@ def test_add_remove_list_extended():
 
     d = apply(b, rops)
     assert a == d
+
+
+def test_add_remove_list_extended_inverse():
+    a = ["a", "b", "c"]
+    b = []
+
+    ops, rops = diff(a, b)
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -40,3 +40,16 @@ def test_add_remove_list():
 
     d = apply(b, rops)
     assert a == d
+
+
+def test_add_remove_list_extended():
+    a = []
+    b = ["a", "b", "c"]
+
+    ops, rops = diff(a, b)
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -7,7 +7,11 @@ def test_apply():
         "a": [5, 7, 9, {"a", "b", "c"}],
         "b": 6,
     }
-    b = {"a": [5, 2, 9, {"b", "c"}], "b": 6, "c": 7}
+    b = {
+        "a": [5, 2, 9, {"b", "c"}],
+        "b": 6,
+        "c": 7,
+    }
     ops, rops = diff(a, b)
 
     assert ops == [
@@ -44,7 +48,7 @@ def test_add_remove_list():
 
 def test_add_remove_list_extended():
     a = []
-    b = ["a", "b", "c"]
+    b = [1, 2, 3]
 
     ops, rops = diff(a, b)
 
@@ -55,9 +59,48 @@ def test_add_remove_list_extended():
     assert a == d
 
 
+def test_insertion_in_list_front():
+    a = [1, 2]
+    b = [3, 1, 2]
+    ops, rops = diff(a, b)
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d
+
+
 def test_add_remove_list_extended_inverse():
-    a = ["a", "b", "c"]
+    a = [1, 2, 3]
     b = []
+
+    ops, rops = diff(a, b)
+    # breakpoint()
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d
+
+
+def test_add_remove_list_extended_inverse_leaving_start():
+    a = [1, 2, 3, 4]
+    b = [1]
+
+    ops, rops = diff(a, b)
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d
+
+
+def test_add_remove_list_extended_inverse_leaving_end():
+    a = [1, 2, 3, 4]
+    b = [4]
 
     ops, rops = diff(a, b)
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,5 +1,4 @@
 from patchdiff import apply, diff
-from patchdiff.pointer import Pointer
 
 
 def test_apply():
@@ -14,18 +13,17 @@ def test_apply():
     }
     ops, rops = diff(a, b)
 
-    assert ops == [
-        {"op": "add", "path": Pointer(["c"]), "value": 7},
-        {"op": "replace", "path": Pointer(["a", 1]), "value": 2},
-        {"op": "remove", "path": Pointer(["a", 3, "a"])},
-    ]
+    c = apply(a, ops)
+    assert c == b
 
-    assert rops == [
-        {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
-        {"op": "replace", "path": Pointer(["a", 1]), "value": 7},
-        {"op": "remove", "path": Pointer(["c"])},
-    ]
+    d = apply(b, rops)
+    assert a == d
 
+
+def test_apply_list():
+    a = [1, 5, 9, "sdfsdf", "fff"]
+    b = ["sdf", 5, 9, "c"]
+    ops, rops = diff(a, b)
     c = apply(a, ops)
     assert c == b
 
@@ -76,7 +74,6 @@ def test_add_remove_list_extended_inverse():
     b = []
 
     ops, rops = diff(a, b)
-    # breakpoint()
 
     c = apply(a, ops)
     assert c == b

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -11,6 +11,7 @@ def test_apply():
         "b": 6,
         "c": 7,
     }
+
     ops, rops = diff(a, b)
 
     c = apply(a, ops)
@@ -23,7 +24,9 @@ def test_apply():
 def test_apply_list():
     a = [1, 5, 9, "sdfsdf", "fff"]
     b = ["sdf", 5, 9, "c"]
+
     ops, rops = diff(a, b)
+
     c = apply(a, ops)
     assert c == b
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2,6 +2,24 @@ from patchdiff import diff
 from patchdiff.pointer import Pointer
 
 
+def test_basic_list_insertion():
+    a = []
+    b = [1]
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "add", "path": Pointer(["-"]), "value": 1}]
+    assert rops == [{"op": "remove", "path": Pointer([0])}]
+
+
+def test_basic_list_deletion():
+    a = [1]
+    b = []
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "remove", "path": Pointer([0])}]
+    assert rops == [{"op": "add", "path": Pointer(["-"]), "value": 1}]
+
+
 def test_list():
     a = [1, 5, 9, "sdfsdf", "fff"]
     b = ["sdf", 5, 9, "c"]
@@ -19,22 +37,26 @@ def test_list():
     ]
 
 
+def test_list_begin():
+    a = [1, 2]
+    b = [3, 1, 2]
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "add", "path": Pointer([0]), "value": 3}]
+    assert rops == [{"op": "remove", "path": Pointer([0])}]
+
+
 def test_list_end():
     a = [1, 2, 3]
     b = [1, 2, 3, 4]
     ops, rops = diff(a, b)
 
-    assert ops == [
-        {"op": "add", "path": Pointer(["-"]), "value": 4},
-    ]
+    assert ops == [{"op": "add", "path": Pointer(["-"]), "value": 4}]
     assert rops == [{"op": "remove", "path": Pointer([3])}]
 
 
 def test_dicts():
-    a = {
-        "a": 5,
-        "b": 6,
-    }
+    a = {"a": 5, "b": 6}
     b = {"a": 3, "b": 6, "c": 7}
     ops, rops = diff(a, b)
 
@@ -68,7 +90,11 @@ def test_mixed():
         "a": [5, 7, 9, {"a", "b", "c"}],
         "b": 6,
     }
-    b = {"a": [5, 2, 9, {"b", "c"}], "b": 6, "c": 7}
+    b = {
+        "a": [5, 2, 9, {"b", "c"}],
+        "b": 6,
+        "c": 7,
+    }
     ops, rops = diff(a, b)
 
     assert ops == [

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -20,6 +20,58 @@ def test_basic_list_deletion():
     assert rops == [{"op": "add", "path": Pointer(["-"]), "value": 1}]
 
 
+def test_basic_list_insertion_half_way():
+    a = [1, 3]
+    b = [1, 2, 3]
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "add", "path": Pointer([1]), "value": 2}]
+    assert rops == [{"op": "remove", "path": Pointer([1])}]
+
+
+def test_basic_list_deletion_half_way():
+    a = [1, 2, 3]
+    b = [1, 3]
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "remove", "path": Pointer([1])}]
+    assert rops == [{"op": "add", "path": Pointer([1]), "value": 2}]
+
+
+def test_basic_list_multiple_insertion():
+    a = []
+    b = [1, 2, 3]
+    ops, rops = diff(a, b)
+
+    assert ops == [
+        {"op": "add", "path": Pointer(["-"]), "value": 1},
+        {"op": "add", "path": Pointer(["-"]), "value": 2},
+        {"op": "add", "path": Pointer(["-"]), "value": 3},
+    ]
+    assert rops == [
+        {"op": "remove", "path": Pointer([0])},
+        {"op": "remove", "path": Pointer([0])},
+        {"op": "remove", "path": Pointer([0])},
+    ]
+
+
+def test_basic_list_multiple_deletion():
+    a = [1, 2, 3]
+    b = []
+    ops, rops = diff(a, b)
+
+    assert ops == [
+        {"op": "remove", "path": Pointer([0])},
+        {"op": "remove", "path": Pointer([0])},
+        {"op": "remove", "path": Pointer([0])},
+    ]
+    assert rops == [
+        {"op": "add", "path": Pointer(["-"]), "value": 1},
+        {"op": "add", "path": Pointer(["-"]), "value": 2},
+        {"op": "add", "path": Pointer(["-"]), "value": 3},
+    ]
+
+
 def test_list():
     a = [1, 5, 9, "sdfsdf", "fff"]
     b = ["sdf", 5, 9, "c"]
@@ -31,9 +83,9 @@ def test_list():
         {"op": "remove", "path": Pointer([4])},
     ]
     assert rops == [
+        {"op": "replace", "path": Pointer([0]), "value": 1},
+        {"op": "replace", "path": Pointer([3]), "value": "sdfsdf"},
         {"op": "add", "path": Pointer(["-"]), "value": "fff"},
-        {"op": "replace", "path": Pointer([4]), "value": "sdfsdf"},
-        {"op": "replace", "path": Pointer([1]), "value": 1},
     ]
 
 
@@ -103,7 +155,7 @@ def test_mixed():
         {"op": "remove", "path": Pointer(["a", 3, "a"])},
     ]
     assert rops == [
-        {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
         {"op": "replace", "path": Pointer(["a", 1]), "value": 7},
+        {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
         {"op": "remove", "path": Pointer(["c"])},
     ]


### PR DESCRIPTION
This PR changes the following:
* Add more (basic) tests
* Fix for indices in list comparisons for both `ops` and `rops`
* Fix for padding of `rops`, taking into account the length of the output instead of input