### PR TITLE
Fix for removing items from dicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Lint
         run: poetry run flake8
       - name: Test
-        run: poetry run pytest
+        run: poetry run pytest -v --cov=patchdiff --cov-report=term-missing
 
   build:
     name: Build and test wheel

--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -96,7 +96,7 @@ def diff_dicts(input: Dict, output: Dict, ptr: Pointer) -> Tuple[List, List]:
     output_keys = set(output.keys())
     for key in input_keys - output_keys:
         ops.append({"op": "remove", "path": ptr.append(key)})
-        rops.insert(0, {"op": "add", "path": ptr.append(key), "value": output[key]})
+        rops.insert(0, {"op": "add", "path": ptr.append(key), "value": input[key]})
     for key in output_keys - input_keys:
         ops.append(
             {

--- a/poetry.lock
+++ b/poetry.lock
@@ -107,6 +107,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coverage"
+version = "7.0.5"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cryptography"
 version = "36.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -124,6 +138,14 @@ pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+
+[[package]]
+name = "docopt"
+version = "0.6.2"
+description = "Pythonic argument parser, that will make you smile"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "docutils"
@@ -393,6 +415,35 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "4.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-watch"
+version = "4.2.0"
+description = "Local continuous test runner with pytest and watchdog."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = ">=0.3.3"
+docopt = ">=0.4.0"
+pytest = ">=2.6.4"
+watchdog = ">=0.6.0"
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.0"
 description = ""
@@ -556,6 +607,17 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
+name = "watchdog"
+version = "2.2.1"
+description = "Filesystem events monitoring"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)"]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
@@ -578,7 +640,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "fcb57b088f6f6383561447ba7ea05333afecca857c1a02318fe842354429a9f0"
+content-hash = "a5e8844310652bc1380eb5b6d338790bacbc110ba3f61f90d9bd4163c023bb70"
 
 [metadata.files]
 atomicwrites = [
@@ -686,6 +748,7 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+coverage = []
 cryptography = [
     {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b"},
     {file = "cryptography-36.0.1-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31"},
@@ -708,6 +771,7 @@ cryptography = [
     {file = "cryptography-36.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316"},
     {file = "cryptography-36.0.1.tar.gz", hash = "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638"},
 ]
+docopt = []
 docutils = [
     {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
     {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
@@ -768,10 +832,7 @@ pkginfo = [
     {file = "pkginfo-1.8.2-py2.py3-none-any.whl", hash = "sha256:c24c487c6a7f72c66e816ab1796b96ac6c3d14d49338293d2141664330b55ffc"},
     {file = "pkginfo-1.8.2.tar.gz", hash = "sha256:542e0d0b6750e2e21c20179803e40ab50598d8066d51097a0e382cba9eb02bff"},
 ]
-platformdirs = [
-    {file = "platformdirs-2.5.0-py3-none-any.whl", hash = "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb"},
-    {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
-]
+platformdirs = []
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -804,6 +865,8 @@ pytest = [
     {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
     {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
 ]
+pytest-cov = []
+pytest-watch = []
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
@@ -882,6 +945,7 @@ urllib3 = [
     {file = "urllib3-1.22-py2.py3-none-any.whl", hash = "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b"},
     {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
 ]
+watchdog = []
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ flake8-black = "*"
 flake8-import-order = "*"
 flake8-print = "*"
 pytest = "*"
+pytest-cov = "*"
+pytest-watch = "*"
 twine = "*"
 
 [build-system]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -159,3 +159,21 @@ def test_mixed():
         {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
         {"op": "remove", "path": Pointer(["c"])},
     ]
+
+
+def test_deep_nested():
+    a = {
+        "a": [
+            {"b": 0},
+        ]
+    }
+    b = {
+        "a": [
+            {"b": 0, "c": 1},
+        ]
+    }
+
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "add", "path": Pointer(["a", 0, "c"]), "value": 1}]
+    assert rops == [{"op": "remove", "path": Pointer(["a", 0, "c"])}]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -122,6 +122,15 @@ def test_dicts():
     ]
 
 
+def test_dicts_remove_item():
+    a = {"a": 3, "b": 6}
+    b = {"a": 3}
+    ops, rops = diff(a, b)
+
+    assert ops == [{"op": "remove", "path": Pointer(["b"])}]
+    assert rops == [{"op": "add", "path": Pointer(["b"]), "value": 6}]
+
+
 def test_sets():
     a = {"a", "b"}
     b = {"a", "c"}
@@ -159,21 +168,3 @@ def test_mixed():
         {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
         {"op": "remove", "path": Pointer(["c"])},
     ]
-
-
-def test_deep_nested():
-    a = {
-        "a": [
-            {"b": 0},
-        ]
-    }
-    b = {
-        "a": [
-            {"b": 0, "c": 1},
-        ]
-    }
-
-    ops, rops = diff(a, b)
-
-    assert ops == [{"op": "add", "path": Pointer(["a", 0, "c"]), "value": 1}]
-    assert rops == [{"op": "remove", "path": Pointer(["a", 0, "c"])}]


### PR DESCRIPTION
Fixes #16 .

~I didn't yet try to minimise the test, but simply adding/removing an item from a dict seemed to work fine, even though I would also expect that to hit the line I changed in diff.py?~

Seems that line 98-99 of diff.py were not covered in the tests. And those lines can be triggered by removing an item from a dict.

Weird thing is: #16 contains a failing example where an item is _added_ to a dict... ~I'm still a bit confused...~ And that happens because of how the diffs between lists are calculated (line 88 kind of switches input/output).