### PR TITLE
Push test coverage to 100% and bump version

### DIFF
--- a/patchdiff/__init__.py
+++ b/patchdiff/__init__.py
@@ -2,4 +2,4 @@ from .apply import apply, iapply
 from .diff import diff
 from .serialize import to_json
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -26,7 +26,7 @@ class Pointer:
 
     @staticmethod
     def from_str(path: str) -> "Pointer":
-        tokens = [unescape(t) for t in path.split("/")]
+        tokens = [unescape(t) for t in path.split("/")[1:]]
         return Pointer(tokens)
 
     def __str__(self) -> str:
@@ -36,7 +36,7 @@ class Pointer:
         return f"Pointer({repr(self.tokens)})"
 
     def __hash__(self) -> int:
-        return hash(self.tokens)
+        return hash(tuple(self.tokens))
 
     def __eq__(self, other: "Pointer") -> bool:
         if not isinstance(other, self.__class__):

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -22,7 +22,7 @@ class Pointer:
     def __init__(self, tokens: List[Hashable] = None) -> None:
         if tokens is None:
             tokens = []
-        self.tokens = tokens
+        self.tokens = tuple(tokens)
 
     @staticmethod
     def from_str(path: str) -> "Pointer":
@@ -33,10 +33,10 @@ class Pointer:
         return "/" + "/".join(escape(str(t)) for t in self.tokens)
 
     def __repr__(self) -> str:
-        return f"Pointer({repr(self.tokens)})"
+        return f"Pointer({repr(list(self.tokens))})"
 
     def __hash__(self) -> int:
-        return hash(tuple(self.tokens))
+        return hash(self.tokens)
 
     def __eq__(self, other: "Pointer") -> bool:
         if not isinstance(other, self.__class__):
@@ -62,4 +62,4 @@ class Pointer:
 
     def append(self, token: Hashable) -> "Pointer":
         """append, creating new Pointer"""
-        return Pointer(self.tokens + [token])
+        return Pointer(self.tokens + (token,))

--- a/patchdiff/types.py
+++ b/patchdiff/types.py
@@ -1,3 +1,3 @@
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Set, Union
 
-Diffable = Union[Dict, List, Set, Tuple]
+Diffable = Union[Dict, List, Set]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchdiff"
-version = "0.3.3"
+version = "0.3.4"
 description = "MIT"
 authors = ["Korijn van Golen <korijn@gmail.com>", "Berend Klein Haneveld <berendkleinhaneveld@gmail.com>"]
 homepage = "https://github.com/fork-tongue/patchdiff"

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -40,3 +40,7 @@ def test_pointer_eq():
     assert Pointer([1]) != Pointer(["1"])
     assert Pointer([1]) != Pointer([0])
     assert Pointer([1]) == Pointer([1])
+
+
+def test_pointer_append():
+    assert Pointer([1]).append("foo") == Pointer([1, "foo"])

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -10,3 +10,33 @@ def test_pointer_get():
 def test_pointer_str():
     assert str(Pointer([1])) == "/1"
     assert str(Pointer(["foo", "bar", "-"])) == "/foo/bar/-"
+
+
+def test_pointer_repr():
+    assert repr(Pointer([1])) == "Pointer([1])"
+    assert repr(Pointer(["foo", "bar", "-"])) == "Pointer(['foo', 'bar', '-'])"
+
+
+def test_pointer_from_str():
+    assert Pointer.from_str("/1") == Pointer(["1"])
+    assert Pointer.from_str("/foo/bar/-") == Pointer(["foo", "bar", "-"])
+
+
+def test_pointer_hash():
+    assert hash(Pointer([1])) == hash((1,))
+    assert hash(Pointer(["foo", "bar", "-"])) == hash(("foo", "bar", "-"))
+
+
+def test_pointer_set():
+    # hash supports comparison operators for use as keys and set elements
+    # so we exercise that as well
+    unique_pointers = [Pointer([1]), Pointer(["2", "3"])]
+    duplicated_pointers = unique_pointers + unique_pointers
+    assert len(set(duplicated_pointers)) == len(unique_pointers)
+
+
+def test_pointer_eq():
+    assert Pointer([1]) != [1]
+    assert Pointer([1]) != Pointer(["1"])
+    assert Pointer([1]) != Pointer([0])
+    assert Pointer([1]) == Pointer([1])


### PR DESCRIPTION
* increase test coverage to 100%
* bump version number
* maintain tokens inside pointer as a tuple (fixes bug in `Pointer.__hash__`)
* fix bug in `Pointer.from_str`
* fix bug in `Diffable` type, `Tuple` is not actually diffable