### PR TITLE
Ignore errors of benchmark on master

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,6 +36,7 @@ jobs:
       # On master: save baseline results
       - name: Run benchmarks and save baseline
         if: github.ref == 'refs/heads/master'
+        continue-on-error: true
         run: |
           uv run --no-sync pytest benchmarks/benchmark.py \
             --benchmark-only \


### PR DESCRIPTION
To make sure benchmark run is saved and cached anyways.