### PR TITLE
Fix for __version__ being different from packaged version

### DIFF
--- a/patchdiff/__init__.py
+++ b/patchdiff/__init__.py
@@ -1,5 +1,7 @@
+from importlib.metadata import version
+
+__version__ = version("patchdiff")
+
 from .apply import apply, iapply
 from .diff import diff
 from .serialize import to_json
-
-__version__ = "0.3.4"


### PR DESCRIPTION
This prevents the version in init to be different from the package version.