### PR TITLE
Fix missing methods on proxies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Format
         run: uv run ruff format --check
       - name: Test
-        run: uv run pytest -v --cov=patchdiff --cov-report=term-missing
+        run: uv run pytest -v --cov=patchdiff --cov-report=term-missing --cov-fail-under=100
 
   build:
     name: Build and test wheel

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -660,7 +660,6 @@ class SetProxy:
                 self.add(value)
 
 
-
 # Add simple reader methods to SetProxy
 _add_reader_methods(
     SetProxy,

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -234,14 +234,6 @@ class DictProxy:
         self.update(other)
         return self
 
-    def __or__(self, other):
-        """Implement | operator (merge), returns a new dict."""
-        return self._data | other
-
-    def __ror__(self, other):
-        """Implement reverse | operator, returns a new dict."""
-        return other | self._data
-
 
 # Add simple reader methods to DictProxy
 _add_reader_methods(
@@ -261,6 +253,8 @@ _add_reader_methods(
         "__format__",
         "__eq__",
         "__ne__",
+        "__or__",
+        "__ror__",
     ],
 )
 # Skipped dict methods:
@@ -527,18 +521,6 @@ class ListProxy:
                 self.extend(original)
         return self
 
-    def __add__(self, other):
-        """Implement + operator, returns a new list."""
-        return self._data + other
-
-    def __mul__(self, n):
-        """Implement * operator, returns a new list."""
-        return self._data * n
-
-    def __rmul__(self, n):
-        """Implement reverse * operator, returns a new list."""
-        return self._data * n
-
 
 # Add simple reader methods to ListProxy
 _add_reader_methods(
@@ -560,6 +542,9 @@ _add_reader_methods(
         "__le__",
         "__gt__",
         "__ge__",
+        "__add__",
+        "__mul__",
+        "__rmul__",
     ],
 )
 # Skipped list methods:
@@ -674,37 +659,6 @@ class SetProxy:
             else:
                 self.add(value)
 
-    def __or__(self, other):
-        """Implement | operator (union), returns a new set."""
-        return self._data | other
-
-    def __ror__(self, other):
-        """Implement reverse | operator, returns a new set."""
-        return other | self._data
-
-    def __and__(self, other):
-        """Implement & operator (intersection), returns a new set."""
-        return self._data & other
-
-    def __rand__(self, other):
-        """Implement reverse & operator, returns a new set."""
-        return other & self._data
-
-    def __sub__(self, other):
-        """Implement - operator (difference), returns a new set."""
-        return self._data - other
-
-    def __rsub__(self, other):
-        """Implement reverse - operator, returns a new set."""
-        return other - self._data
-
-    def __xor__(self, other):
-        """Implement ^ operator (symmetric difference), returns a new set."""
-        return self._data ^ other
-
-    def __rxor__(self, other):
-        """Implement reverse ^ operator, returns a new set."""
-        return other ^ self._data
 
 
 # Add simple reader methods to SetProxy
@@ -731,6 +685,14 @@ _add_reader_methods(
         "__lt__",
         "__ge__",
         "__gt__",
+        "__or__",
+        "__ror__",
+        "__and__",
+        "__rand__",
+        "__sub__",
+        "__rsub__",
+        "__xor__",
+        "__rxor__",
     ],
 )
 # Skipped set methods:

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -217,6 +217,38 @@ class DictProxy:
             del self._proxies[key]
         return key, value
 
+    def values(self):
+        """Return proxied values so nested mutations are tracked."""
+        for key in self._data:
+            yield self._wrap(key, self._data[key])
+
+    def items(self):
+        """Return (key, proxied_value) pairs so nested mutations are tracked."""
+        for key in self._data:
+            yield key, self._wrap(key, self._data[key])
+
+    def __ior__(self, other):
+        """Implement |= operator (merge update)."""
+        self.update(other)
+        return self
+
+    def __or__(self, other):
+        """Implement | operator (merge), returns a new dict."""
+        return self._data | other
+
+    def __ror__(self, other):
+        """Implement reverse | operator, returns a new dict."""
+        return other | self._data
+
+    def __eq__(self, other):
+        return self._data == other
+
+    def __ne__(self, other):
+        return self._data != other
+
+    def __bool__(self):
+        return bool(self._data)
+
 
 # Add simple reader methods to DictProxy
 _add_reader_methods(
@@ -226,13 +258,21 @@ _add_reader_methods(
         "__contains__",
         "__repr__",
         "__iter__",
+        # __reversed__ returns keys (not values), so pass-through is fine
         "__reversed__",
         "keys",
-        "values",
-        "items",
+        # values() and items() are implemented as custom methods above
+        # to return proxied nested objects
         "copy",
+        "__str__",
+        "__format__",
     ],
 )
+# Skipped dict methods:
+# - fromkeys: classmethod, not relevant for proxy instances
+# - __class_getitem__: typing support (dict[str, int]), not relevant for instances
+# - __hash__: dicts are unhashable, same for proxy
+# - __lt__, __le__, __gt__, __ge__: dicts don't support ordering comparisons
 
 
 class ListProxy:
@@ -466,6 +506,68 @@ class ListProxy:
         # Invalidate all proxy caches as positions changed
         self._proxies.clear()
 
+    def __iter__(self):
+        """Iterate over list elements, wrapping nested structures in proxies."""
+        for i in range(len(self._data)):
+            yield self._wrap(i, self._data[i])
+
+    def __reversed__(self):
+        """Iterate in reverse, wrapping nested structures in proxies."""
+        for i in range(len(self._data) - 1, -1, -1):
+            yield self._wrap(i, self._data[i])
+
+    def __iadd__(self, other):
+        """Implement += operator (in-place extend)."""
+        self.extend(other)
+        return self
+
+    def __imul__(self, n):
+        """Implement *= operator (in-place repeat)."""
+        if n <= 0:
+            self.clear()
+        elif n > 1:
+            original = list(self._data)
+            for _ in range(n - 1):
+                self.extend(original)
+        return self
+
+    def __add__(self, other):
+        """Implement + operator, returns a new list."""
+        return self._data + other
+
+    def __radd__(self, other):
+        """Implement reverse + operator, returns a new list."""
+        return other + self._data
+
+    def __mul__(self, n):
+        """Implement * operator, returns a new list."""
+        return self._data * n
+
+    def __rmul__(self, n):
+        """Implement reverse * operator, returns a new list."""
+        return self._data * n
+
+    def __eq__(self, other):
+        return self._data == other
+
+    def __ne__(self, other):
+        return self._data != other
+
+    def __lt__(self, other):
+        return self._data < other
+
+    def __le__(self, other):
+        return self._data <= other
+
+    def __gt__(self, other):
+        return self._data > other
+
+    def __ge__(self, other):
+        return self._data >= other
+
+    def __bool__(self):
+        return bool(self._data)
+
 
 # Add simple reader methods to ListProxy
 _add_reader_methods(
@@ -474,13 +576,18 @@ _add_reader_methods(
         "__len__",
         "__contains__",
         "__repr__",
-        "__iter__",
-        "__reversed__",
+        # __iter__ and __reversed__ are implemented as custom methods above
+        # to return proxied nested objects
         "index",
         "count",
         "copy",
+        "__str__",
+        "__format__",
     ],
 )
+# Skipped list methods:
+# - __class_getitem__: typing support (list[int]), not relevant for instances
+# - __hash__: lists are unhashable, same for proxy
 
 
 class SetProxy:
@@ -564,6 +671,84 @@ class SetProxy:
                 self.add(value)
         return self
 
+    def difference_update(self, *others):
+        """Remove all elements found in others."""
+        for other in others:
+            for value in other:
+                if value in self._data:
+                    self.remove(value)
+
+    def intersection_update(self, *others):
+        """Keep only elements found in all others."""
+        # Compute the intersection first, then remove what's not in it
+        keep = self._data.copy()
+        for other in others:
+            keep &= set(other)
+        values_to_remove = [v for v in self._data if v not in keep]
+        for value in values_to_remove:
+            self.remove(value)
+
+    def symmetric_difference_update(self, other):
+        """Update with symmetric difference."""
+        for value in other:
+            if value in self._data:
+                self.remove(value)
+            else:
+                self.add(value)
+
+    def __or__(self, other):
+        """Implement | operator (union), returns a new set."""
+        return self._data | other
+
+    def __ror__(self, other):
+        """Implement reverse | operator, returns a new set."""
+        return other | self._data
+
+    def __and__(self, other):
+        """Implement & operator (intersection), returns a new set."""
+        return self._data & other
+
+    def __rand__(self, other):
+        """Implement reverse & operator, returns a new set."""
+        return other & self._data
+
+    def __sub__(self, other):
+        """Implement - operator (difference), returns a new set."""
+        return self._data - other
+
+    def __rsub__(self, other):
+        """Implement reverse - operator, returns a new set."""
+        return other - self._data
+
+    def __xor__(self, other):
+        """Implement ^ operator (symmetric difference), returns a new set."""
+        return self._data ^ other
+
+    def __rxor__(self, other):
+        """Implement reverse ^ operator, returns a new set."""
+        return other ^ self._data
+
+    def __eq__(self, other):
+        return self._data == other
+
+    def __ne__(self, other):
+        return self._data != other
+
+    def __le__(self, other):
+        return self._data <= other
+
+    def __lt__(self, other):
+        return self._data < other
+
+    def __ge__(self, other):
+        return self._data >= other
+
+    def __gt__(self, other):
+        return self._data > other
+
+    def __bool__(self):
+        return bool(self._data)
+
 
 # Add simple reader methods to SetProxy
 _add_reader_methods(
@@ -581,8 +766,13 @@ _add_reader_methods(
         "issubset",
         "issuperset",
         "copy",
+        "__str__",
+        "__format__",
     ],
 )
+# Skipped set methods:
+# - __class_getitem__: typing support (set[int]), not relevant for instances
+# - __hash__: sets are unhashable, same for proxy
 
 
 def produce(

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -98,6 +98,8 @@ class PatchRecorder:
 class DictProxy:
     """Proxy for dict objects that tracks mutations and generates patches."""
 
+    __hash__ = None  # dicts are unhashable
+
     def __init__(self, data: Dict, recorder: PatchRecorder, path: Pointer):
         self._data = data
         self._recorder = recorder
@@ -264,12 +266,13 @@ _add_reader_methods(
 # Skipped dict methods:
 # - fromkeys: classmethod, not relevant for proxy instances
 # - __class_getitem__: typing support (dict[str, int]), not relevant for instances
-# - __hash__: dicts are unhashable, same for proxy
 # - __lt__, __le__, __gt__, __ge__: dicts don't support ordering comparisons
 
 
 class ListProxy:
     """Proxy for list objects that tracks mutations and generates patches."""
+
+    __hash__ = None  # lists are unhashable
 
     def __init__(self, data: List, recorder: PatchRecorder, path: Pointer):
         self._data = data
@@ -528,10 +531,6 @@ class ListProxy:
         """Implement + operator, returns a new list."""
         return self._data + other
 
-    def __radd__(self, other):
-        """Implement reverse + operator, returns a new list."""
-        return other + self._data
-
     def __mul__(self, n):
         """Implement * operator, returns a new list."""
         return self._data * n
@@ -565,11 +564,12 @@ _add_reader_methods(
 )
 # Skipped list methods:
 # - __class_getitem__: typing support (list[int]), not relevant for instances
-# - __hash__: lists are unhashable, same for proxy
 
 
 class SetProxy:
     """Proxy for set objects that tracks mutations and generates patches."""
+
+    __hash__ = None  # sets are unhashable
 
     def __init__(self, data: Set, recorder: PatchRecorder, path: Pointer):
         self._data = data
@@ -735,7 +735,6 @@ _add_reader_methods(
 )
 # Skipped set methods:
 # - __class_getitem__: typing support (set[int]), not relevant for instances
-# - __hash__: sets are unhashable, same for proxy
 
 
 def produce(

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -240,15 +240,6 @@ class DictProxy:
         """Implement reverse | operator, returns a new dict."""
         return other | self._data
 
-    def __eq__(self, other):
-        return self._data == other
-
-    def __ne__(self, other):
-        return self._data != other
-
-    def __bool__(self):
-        return bool(self._data)
-
 
 # Add simple reader methods to DictProxy
 _add_reader_methods(
@@ -266,6 +257,8 @@ _add_reader_methods(
         "copy",
         "__str__",
         "__format__",
+        "__eq__",
+        "__ne__",
     ],
 )
 # Skipped dict methods:
@@ -547,27 +540,6 @@ class ListProxy:
         """Implement reverse * operator, returns a new list."""
         return self._data * n
 
-    def __eq__(self, other):
-        return self._data == other
-
-    def __ne__(self, other):
-        return self._data != other
-
-    def __lt__(self, other):
-        return self._data < other
-
-    def __le__(self, other):
-        return self._data <= other
-
-    def __gt__(self, other):
-        return self._data > other
-
-    def __ge__(self, other):
-        return self._data >= other
-
-    def __bool__(self):
-        return bool(self._data)
-
 
 # Add simple reader methods to ListProxy
 _add_reader_methods(
@@ -583,6 +555,12 @@ _add_reader_methods(
         "copy",
         "__str__",
         "__format__",
+        "__eq__",
+        "__ne__",
+        "__lt__",
+        "__le__",
+        "__gt__",
+        "__ge__",
     ],
 )
 # Skipped list methods:
@@ -728,27 +706,6 @@ class SetProxy:
         """Implement reverse ^ operator, returns a new set."""
         return other ^ self._data
 
-    def __eq__(self, other):
-        return self._data == other
-
-    def __ne__(self, other):
-        return self._data != other
-
-    def __le__(self, other):
-        return self._data <= other
-
-    def __lt__(self, other):
-        return self._data < other
-
-    def __ge__(self, other):
-        return self._data >= other
-
-    def __gt__(self, other):
-        return self._data > other
-
-    def __bool__(self):
-        return bool(self._data)
-
 
 # Add simple reader methods to SetProxy
 _add_reader_methods(
@@ -768,6 +725,12 @@ _add_reader_methods(
         "copy",
         "__str__",
         "__format__",
+        "__eq__",
+        "__ne__",
+        "__le__",
+        "__lt__",
+        "__ge__",
+        "__gt__",
     ],
 )
 # Skipped set methods:

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -98,6 +98,7 @@ class PatchRecorder:
 class DictProxy:
     """Proxy for dict objects that tracks mutations and generates patches."""
 
+    __slots__ = ("_data", "_path", "_proxies", "_recorder")
     __hash__ = None  # dicts are unhashable
 
     def __init__(self, data: Dict, recorder: PatchRecorder, path: Pointer):
@@ -266,6 +267,7 @@ _add_reader_methods(
 class ListProxy:
     """Proxy for list objects that tracks mutations and generates patches."""
 
+    __slots__ = ("_data", "_path", "_proxies", "_recorder")
     __hash__ = None  # lists are unhashable
 
     def __init__(self, data: List, recorder: PatchRecorder, path: Pointer):
@@ -554,6 +556,7 @@ _add_reader_methods(
 class SetProxy:
     """Proxy for set objects that tracks mutations and generates patches."""
 
+    __slots__ = ("_data", "_path", "_recorder")
     __hash__ = None  # sets are unhashable
 
     def __init__(self, data: Set, recorder: PatchRecorder, path: Pointer):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -43,7 +43,12 @@ def test_apply_empty():
         "a": [5, 7, 9, {"a", "b", "c"}],
         "b": 6,
     }
+    assert a == b
+
     ops, rops = diff(a, b)
+
+    assert not ops
+    assert not rops
 
     c = apply(a, ops)
     assert c == b

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -34,6 +34,24 @@ def test_apply_list():
     assert a == d
 
 
+def test_apply_empty():
+    a = {
+        "a": [5, 7, 9, {"a", "b", "c"}],
+        "b": 6,
+    }
+    b = {
+        "a": [5, 7, 9, {"a", "b", "c"}],
+        "b": 6,
+    }
+    ops, rops = diff(a, b)
+
+    c = apply(a, ops)
+    assert c == b
+
+    d = apply(b, rops)
+    assert a == d
+
+
 def test_add_remove_list():
     a = []
     b = [1]

--- a/tests/test_produce_core.py
+++ b/tests/test_produce_core.py
@@ -793,3 +793,79 @@ def test_cross_level_modifications():
     assert result["level1"]["sibling"][0]["a"] == 10
 
     assert len(patches) >= 7
+
+
+# -- Proxy API completeness tests --
+# These tests ensure that proxy classes cover all methods of their base types.
+# If a new Python version adds a method to dict/list/set, the corresponding
+# test will fail. To fix it, either:
+# 1. Add the method name to SKIPPED below (if it doesn't need proxying), or
+# 2. Implement it on the proxy class.
+
+from patchdiff.produce import DictProxy, ListProxy, SetProxy
+
+# Methods inherited from object that are not part of the container API
+_OBJECT_INTERNALS = {
+    "__class__",
+    "__delattr__",
+    "__dir__",
+    "__doc__",
+    "__getattribute__",
+    "__getstate__",
+    "__init__",
+    "__init_subclass__",
+    "__new__",
+    "__reduce__",
+    "__reduce_ex__",
+    "__setattr__",
+    "__sizeof__",
+    "__subclasshook__",
+}
+
+
+def _unhandled_methods(proxy_cls, base_cls, skipped):
+    """Return methods on base_cls that are missing from proxy_cls and not in skipped."""
+    base_methods = set(dir(base_cls)) - _OBJECT_INTERNALS
+    proxy_methods = set(dir(proxy_cls)) - _OBJECT_INTERNALS
+    return (base_methods - proxy_methods) - set(skipped)
+
+
+class TestProxyApiCompleteness:
+    """Verify proxy classes implement all methods of their base types."""
+
+    # Methods intentionally not implemented on the proxy classes.
+    # If a new Python version adds a method to dict/list/set, the test will
+    # fail. To fix, either implement the method or add it here.
+    DICT_SKIPPED = {
+        "fromkeys",  # classmethod, not relevant for proxy instances
+        "__class_getitem__",  # typing support (dict[str, int])
+    }
+
+    LIST_SKIPPED = {
+        "__class_getitem__",  # typing support (list[int])
+    }
+
+    SET_SKIPPED = {
+        "__class_getitem__",  # typing support (set[int])
+    }
+
+    def test_dict_proxy_api_completeness(self):
+        unhandled = _unhandled_methods(DictProxy, dict, self.DICT_SKIPPED)
+        assert not unhandled, (
+            f"DictProxy is missing methods from dict: {sorted(unhandled)}. "
+            f"Either implement them on DictProxy or add to DICT_SKIPPED."
+        )
+
+    def test_list_proxy_api_completeness(self):
+        unhandled = _unhandled_methods(ListProxy, list, self.LIST_SKIPPED)
+        assert not unhandled, (
+            f"ListProxy is missing methods from list: {sorted(unhandled)}. "
+            f"Either implement them on ListProxy or add to LIST_SKIPPED."
+        )
+
+    def test_set_proxy_api_completeness(self):
+        unhandled = _unhandled_methods(SetProxy, set, self.SET_SKIPPED)
+        assert not unhandled, (
+            f"SetProxy is missing methods from set: {sorted(unhandled)}. "
+            f"Either implement them on SetProxy or add to SET_SKIPPED."
+        )

--- a/tests/test_produce_core.py
+++ b/tests/test_produce_core.py
@@ -3,6 +3,7 @@
 import pytest
 
 from patchdiff import apply, produce
+from patchdiff.produce import DictProxy, ListProxy, SetProxy
 
 
 def assert_patches_work(base, recipe):
@@ -802,8 +803,6 @@ def test_cross_level_modifications():
 # 1. Add the method name to SKIPPED below (if it doesn't need proxying), or
 # 2. Implement it on the proxy class.
 
-from patchdiff.produce import DictProxy, ListProxy, SetProxy
-
 # Methods inherited from object that are not part of the container API
 _OBJECT_INTERNALS = {
     "__class__",
@@ -830,42 +829,43 @@ def _unhandled_methods(proxy_cls, base_cls, skipped):
     return (base_methods - proxy_methods) - set(skipped)
 
 
+# Methods intentionally not implemented on the proxy classes.
+# If a new Python version adds a method to dict/list/set, the test will
+# fail. To fix, either implement the method or add it here.
+_DICT_SKIPPED = {
+    "fromkeys",  # classmethod, not relevant for proxy instances
+    "__class_getitem__",  # typing support (dict[str, int])
+}
+
+_LIST_SKIPPED = {
+    "__class_getitem__",  # typing support (list[int])
+}
+
+_SET_SKIPPED = {
+    "__class_getitem__",  # typing support (set[int])
+}
+
+
 class TestProxyApiCompleteness:
     """Verify proxy classes implement all methods of their base types."""
 
-    # Methods intentionally not implemented on the proxy classes.
-    # If a new Python version adds a method to dict/list/set, the test will
-    # fail. To fix, either implement the method or add it here.
-    DICT_SKIPPED = {
-        "fromkeys",  # classmethod, not relevant for proxy instances
-        "__class_getitem__",  # typing support (dict[str, int])
-    }
-
-    LIST_SKIPPED = {
-        "__class_getitem__",  # typing support (list[int])
-    }
-
-    SET_SKIPPED = {
-        "__class_getitem__",  # typing support (set[int])
-    }
-
     def test_dict_proxy_api_completeness(self):
-        unhandled = _unhandled_methods(DictProxy, dict, self.DICT_SKIPPED)
+        unhandled = _unhandled_methods(DictProxy, dict, _DICT_SKIPPED)
         assert not unhandled, (
             f"DictProxy is missing methods from dict: {sorted(unhandled)}. "
-            f"Either implement them on DictProxy or add to DICT_SKIPPED."
+            f"Either implement them on DictProxy or add to _DICT_SKIPPED."
         )
 
     def test_list_proxy_api_completeness(self):
-        unhandled = _unhandled_methods(ListProxy, list, self.LIST_SKIPPED)
+        unhandled = _unhandled_methods(ListProxy, list, _LIST_SKIPPED)
         assert not unhandled, (
             f"ListProxy is missing methods from list: {sorted(unhandled)}. "
-            f"Either implement them on ListProxy or add to LIST_SKIPPED."
+            f"Either implement them on ListProxy or add to _LIST_SKIPPED."
         )
 
     def test_set_proxy_api_completeness(self):
-        unhandled = _unhandled_methods(SetProxy, set, self.SET_SKIPPED)
+        unhandled = _unhandled_methods(SetProxy, set, _SET_SKIPPED)
         assert not unhandled, (
             f"SetProxy is missing methods from set: {sorted(unhandled)}. "
-            f"Either implement them on SetProxy or add to SET_SKIPPED."
+            f"Either implement them on SetProxy or add to _SET_SKIPPED."
         )

--- a/tests/test_produce_dict.py
+++ b/tests/test_produce_dict.py
@@ -567,6 +567,98 @@ def test_dict_get_none_implicit():
     assert result == {"a": 1}
 
 
+def test_dict_values_returns_proxied_nested():
+    """Test that values() returns proxied nested objects."""
+    base = {"a": {"x": 1}, "b": {"x": 2}}
+
+    def recipe(draft):
+        for v in draft.values():
+            v["x"] = 99
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {"a": {"x": 99}, "b": {"x": 99}}
+    assert len(patches) == 2
+
+
+def test_dict_items_returns_proxied_nested():
+    """Test that items() returns proxied nested objects."""
+    base = {"a": {"x": 1}, "b": {"x": 2}}
+
+    def recipe(draft):
+        for k, v in draft.items():
+            v["x"] = 99
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {"a": {"x": 99}, "b": {"x": 99}}
+    assert len(patches) == 2
+
+
+def test_dict_ior_operator():
+    """Test |= operator (merge update) on dict proxy."""
+    base = {"a": 1}
+
+    def recipe(draft):
+        draft |= {"b": 2, "c": 3}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {"a": 1, "b": 2, "c": 3}
+    assert len(patches) == 2
+
+
+def test_dict_or_operator():
+    """Test | operator (merge) on dict proxy returns new dict."""
+    base = {"a": 1}
+
+    def recipe(draft):
+        merged = draft | {"b": 2}
+        assert isinstance(merged, dict)
+        assert merged == {"a": 1, "b": 2}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []  # No mutations to draft
+
+
+def test_dict_eq():
+    """Test __eq__ on dict proxy."""
+    base = {"a": 1, "b": 2}
+
+    def recipe(draft):
+        assert draft == {"a": 1, "b": 2}
+        assert not (draft == {"a": 1})
+
+    produce(base, recipe)
+
+
+def test_dict_ne():
+    """Test __ne__ on dict proxy."""
+    base = {"a": 1}
+
+    def recipe(draft):
+        assert draft != {"b": 2}
+        assert not (draft != {"a": 1})
+
+    produce(base, recipe)
+
+
+def test_dict_bool():
+    """Test __bool__ on dict proxy."""
+    base_empty = {}
+    base_full = {"a": 1}
+
+    def recipe_empty(draft):
+        assert not draft
+
+    def recipe_full(draft):
+        assert draft
+
+    produce(base_empty, recipe_empty)
+    produce(base_full, recipe_full)
+
+
 def test_dict_get_none_explicit():
     """Test get() with explicit None default."""
     base = {"a": 1}

--- a/tests/test_produce_dict.py
+++ b/tests/test_produce_dict.py
@@ -102,6 +102,23 @@ def test_dict_pop():
     assert patches[0]["op"] == "remove"
 
 
+def test_dict_pop_invalidates_proxy_cache():
+    """Test that pop() invalidates the proxy cache for nested structures."""
+    base = {"nested": {"a": 1}, "other": 2}
+
+    def recipe(draft):
+        # Access nested to populate the proxy cache
+        _ = draft["nested"]["a"]
+        # Pop the key that has a cached proxy
+        draft.pop("nested")
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {"other": 2}
+    assert len(patches) == 1
+    assert patches[0]["op"] == "remove"
+
+
 def test_dict_update():
     """Test dict.update() operation."""
     base = {"a": 1}
@@ -277,6 +294,23 @@ def test_dict_popitem():
     result, patches, _reverse = produce(base, recipe)
 
     assert len(result) == 1
+    assert len(patches) == 1
+    assert patches[0]["op"] == "remove"
+
+
+def test_dict_popitem_invalidates_proxy_cache():
+    """Test that popitem() invalidates the proxy cache for nested structures."""
+    base = {"a": {"x": 1}}
+
+    def recipe(draft):
+        # Access nested to populate the proxy cache
+        _ = draft["a"]["x"]
+        # popitem removes the only key which has a cached proxy
+        draft.popitem()
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {}
     assert len(patches) == 1
     assert patches[0]["op"] == "remove"
 

--- a/tests/test_produce_dict.py
+++ b/tests/test_produce_dict.py
@@ -651,7 +651,7 @@ def test_dict_or_operator():
         assert isinstance(merged, dict)
         assert merged == {"a": 1, "b": 2}
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []  # No mutations to draft
 

--- a/tests/test_produce_list.py
+++ b/tests/test_produce_list.py
@@ -1056,11 +1056,11 @@ def test_list_add_operator():
     base = [1, 2]
 
     def recipe(draft):
-        new = draft + [3, 4]
+        new = draft + [3, 4]  # noqa: RUF005
         assert isinstance(new, list)
         assert new == [1, 2, 3, 4]
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 
@@ -1074,7 +1074,7 @@ def test_list_mul_operator():
         assert isinstance(new, list)
         assert new == [1, 2, 1, 2, 1, 2]
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 
@@ -1088,7 +1088,7 @@ def test_list_rmul_operator():
         assert isinstance(new, list)
         assert new == [1, 2, 1, 2, 1, 2]
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 

--- a/tests/test_produce_list.py
+++ b/tests/test_produce_list.py
@@ -982,3 +982,147 @@ def test_list_count_empty_list():
     result, _patches, _reverse = produce(base, recipe)
 
     assert result == []
+
+
+def test_list_iter_returns_proxied_nested():
+    """Test that __iter__ returns proxied nested objects."""
+    base = [{"x": 1}, {"x": 2}]
+
+    def recipe(draft):
+        for item in draft:
+            item["x"] = 99
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == [{"x": 99}, {"x": 99}]
+    assert len(patches) == 2
+
+
+def test_list_reversed_returns_proxied_nested():
+    """Test that __reversed__ returns proxied nested objects."""
+    base = [{"x": 1}, {"x": 2}]
+
+    def recipe(draft):
+        for item in reversed(draft):
+            item["x"] = 99
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == [{"x": 99}, {"x": 99}]
+    assert len(patches) == 2
+
+
+def test_list_iadd_operator():
+    """Test += operator (in-place add, like extend) on list proxy."""
+    base = [1, 2]
+
+    def recipe(draft):
+        draft += [3, 4]
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == [1, 2, 3, 4]
+    assert len(patches) == 2
+
+
+def test_list_imul_operator():
+    """Test *= operator (in-place repeat) on list proxy."""
+    base = [1, 2]
+
+    def recipe(draft):
+        draft *= 3
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == [1, 2, 1, 2, 1, 2]
+    assert len(patches) == 4  # 4 new elements added
+
+
+def test_list_add_operator():
+    """Test + operator returns new list, not a proxy."""
+    base = [1, 2]
+
+    def recipe(draft):
+        new = draft + [3, 4]
+        assert isinstance(new, list)
+        assert new == [1, 2, 3, 4]
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_list_mul_operator():
+    """Test * operator returns new list, not a proxy."""
+    base = [1, 2]
+
+    def recipe(draft):
+        new = draft * 3
+        assert isinstance(new, list)
+        assert new == [1, 2, 1, 2, 1, 2]
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_list_rmul_operator():
+    """Test reverse * operator (int * list) returns new list."""
+    base = [1, 2]
+
+    def recipe(draft):
+        new = 3 * draft
+        assert isinstance(new, list)
+        assert new == [1, 2, 1, 2, 1, 2]
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_list_eq():
+    """Test __eq__ on list proxy."""
+    base = [1, 2, 3]
+
+    def recipe(draft):
+        assert draft == [1, 2, 3]
+        assert not (draft == [1, 2])
+
+    produce(base, recipe)
+
+
+def test_list_ne():
+    """Test __ne__ on list proxy."""
+    base = [1, 2, 3]
+
+    def recipe(draft):
+        assert draft != [1, 2]
+        assert not (draft != [1, 2, 3])
+
+    produce(base, recipe)
+
+
+def test_list_bool():
+    """Test __bool__ on list proxy."""
+
+    def recipe_empty(draft):
+        assert not draft
+
+    def recipe_full(draft):
+        assert draft
+
+    produce([], recipe_empty)
+    produce([1], recipe_full)
+
+
+def test_list_lt_le_gt_ge():
+    """Test comparison operators on list proxy."""
+    base = [1, 2, 3]
+
+    def recipe(draft):
+        assert draft < [1, 2, 4]
+        assert draft <= [1, 2, 3]
+        assert draft > [1, 2, 2]
+        assert draft >= [1, 2, 3]
+
+    produce(base, recipe)

--- a/tests/test_produce_list.py
+++ b/tests/test_produce_list.py
@@ -1038,6 +1038,19 @@ def test_list_imul_operator():
     assert len(patches) == 4  # 4 new elements added
 
 
+def test_list_imul_zero():
+    """Test *= 0 clears the list."""
+    base = [1, 2, 3]
+
+    def recipe(draft):
+        draft *= 0
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == []
+    assert len(patches) == 3  # 3 elements removed
+
+
 def test_list_add_operator():
     """Test + operator returns new list, not a proxy."""
     base = [1, 2]

--- a/tests/test_produce_set.py
+++ b/tests/test_produce_set.py
@@ -535,3 +535,148 @@ def test_set_issuperset_self():
     result, _patches, _reverse = produce(base, recipe)
 
     assert result == base
+
+
+def test_set_difference_update_method():
+    """Test difference_update() method on set proxy."""
+    base = {1, 2, 3, 4}
+
+    def recipe(draft):
+        draft.difference_update({2, 4})
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {1, 3}
+    assert len(patches) == 2
+
+
+def test_set_intersection_update_method():
+    """Test intersection_update() method on set proxy."""
+    base = {1, 2, 3, 4}
+
+    def recipe(draft):
+        draft.intersection_update({2, 3, 5})
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {2, 3}
+    assert len(patches) == 2  # Removed 1 and 4
+
+
+def test_set_symmetric_difference_update_method():
+    """Test symmetric_difference_update() method on set proxy."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        draft.symmetric_difference_update({2, 3, 4})
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert result == {1, 4}
+    assert len(patches) == 3  # Removed 2, 3, added 4
+
+
+def test_set_or_operator():
+    """Test | operator (union) returns new set, not a proxy."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        new = draft | {3, 4, 5}
+        assert isinstance(new, set)
+        assert new == {1, 2, 3, 4, 5}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_set_and_operator():
+    """Test & operator (intersection) returns new set."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        new = draft & {2, 3, 4}
+        assert isinstance(new, set)
+        assert new == {2, 3}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_set_sub_operator():
+    """Test - operator (difference) returns new set."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        new = draft - {2, 4}
+        assert isinstance(new, set)
+        assert new == {1, 3}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_set_xor_operator():
+    """Test ^ operator (symmetric difference) returns new set."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        new = draft ^ {2, 3, 4}
+        assert isinstance(new, set)
+        assert new == {1, 4}
+
+    result, patches, _reverse = produce(base, recipe)
+
+    assert patches == []
+
+
+def test_set_eq():
+    """Test __eq__ on set proxy."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        assert draft == {1, 2, 3}
+        assert not (draft == {1, 2})
+
+    produce(base, recipe)
+
+
+def test_set_ne():
+    """Test __ne__ on set proxy."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        assert draft != {1, 2}
+        assert not (draft != {1, 2, 3})
+
+    produce(base, recipe)
+
+
+def test_set_bool():
+    """Test __bool__ on set proxy."""
+
+    def recipe_empty(draft):
+        assert not draft
+
+    def recipe_full(draft):
+        assert draft
+
+    produce(set(), recipe_empty)
+    produce({1}, recipe_full)
+
+
+def test_set_le_lt_ge_gt():
+    """Test comparison operators on set proxy (subset/superset)."""
+    base = {1, 2, 3}
+
+    def recipe(draft):
+        assert draft <= {1, 2, 3, 4}  # subset
+        assert draft <= {1, 2, 3}  # equal is also <=
+        assert draft < {1, 2, 3, 4}  # proper subset
+        assert not (draft < {1, 2, 3})  # not proper subset of equal
+        assert draft >= {1, 2}  # superset
+        assert draft > {1, 2}  # proper superset
+
+    produce(base, recipe)

--- a/tests/test_produce_set.py
+++ b/tests/test_produce_set.py
@@ -585,7 +585,7 @@ def test_set_or_operator():
         assert isinstance(new, set)
         assert new == {1, 2, 3, 4, 5}
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 
@@ -599,7 +599,7 @@ def test_set_and_operator():
         assert isinstance(new, set)
         assert new == {2, 3}
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 
@@ -613,7 +613,7 @@ def test_set_sub_operator():
         assert isinstance(new, set)
         assert new == {1, 3}
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 
@@ -627,7 +627,7 @@ def test_set_xor_operator():
         assert isinstance(new, set)
         assert new == {1, 4}
 
-    result, patches, _reverse = produce(base, recipe)
+    _result, patches, _reverse = produce(base, recipe)
 
     assert patches == []
 


### PR DESCRIPTION
I noticed some problems producing patches because of missing implementations of proxy methods.

Now all methods should be covered. The test suite also now checks for an expected list of supported (and unsupported) methods.
And restore 100% code coverage.