### PR TITLE
fix: to_json no longer mutates caller's ops

### DIFF
--- a/patchdiff/serialize.py
+++ b/patchdiff/serialize.py
@@ -3,10 +3,7 @@ from typing import List
 
 
 def to_str_paths(ops: List) -> List:
-    str_ops = ops.copy()
-    for op in str_ops:
-        op["path"] = str(op["path"])
-    return str_ops
+    return [{**op, "path": str(op["path"])} for op in ops]
 
 
 def to_json(ops: List, **kwargs) -> str:

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,4 +1,14 @@
-from patchdiff import diff, to_json
+from patchdiff import apply, diff, to_json
+
+
+def test_to_json_does_not_mutate_ops():
+    a = {"x": [1, 2, 3]}
+    b = {"x": [1, 9, 3]}
+    ops, _ = diff(a, b)
+
+    to_json(ops)
+
+    assert apply(a, ops) == b
 
 
 def test_to_json():


### PR DESCRIPTION
## Summary

`patchdiff.to_json(ops)` was mutating the caller's `ops`. `to_str_paths` did a shallow `ops.copy()`, so the inner dicts were still shared. Overwriting `op[\"path\"]` with `str(op[\"path\"])` then replaced the `Pointer` in the caller's dicts with strings, which broke subsequent `apply()` calls. Fix by copying each dict (`{**op, \"path\": str(op[\"path\"])}`) instead of just the outer list.

## Reproducer on `master`

```bash
uv run python -c "
from patchdiff import diff, apply, to_json
a = {'x': [1, 2, 3]}
b = {'x': [1, 9, 3]}
ops, _ = diff(a, b)
to_json(ops)
print(apply(a, ops))
"
```

On `master` this raises:

```
Traceback (most recent call last):
  File "<string>", line 7, in <module>
    print(apply(a, ops))
  File "patchdiff/apply.py", line 48, in apply
    return iapply(deepcopy(obj), patches)
  File "patchdiff/apply.py", line 14, in iapply
    parent, key, _ = ptr.evaluate(obj)
AttributeError: 'str' object has no attribute 'evaluate'
```

On this branch it prints `{'x': [1, 9, 3]}`.

## New test

- `tests/test_serialize.py::test_to_json_does_not_mutate_ops` — calls `to_json(ops)`, discards the result, then asserts `apply(a, ops) == b`. Fails on `master` with the traceback above; passes on this branch.

## Existing tests

- `tests/test_serialize.py::test_to_json` still passes (sanity check on the JSON output).
- Full `uv run pytest -x -q` is green (269 passed).

## Test plan

- [x] `uv run pytest tests/test_serialize.py -v`
- [x] `uv run pytest -x -q`
- [x] `uv run ruff check patchdiff/serialize.py tests/test_serialize.py`
- [x] `uv run ruff format --check patchdiff/serialize.py tests/test_serialize.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)