### PR TITLE
fix: produce() snapshots mutable values when recording patches

### DIFF
--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -7,14 +7,10 @@ This approach is inspired by Immer's proxy-based implementation.
 
 from __future__ import annotations
 
-import copy
+from copy import deepcopy
 from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 from .pointer import Pointer
-
-# Local alias to avoid the `copy` global + `.deepcopy` attribute lookup on
-# every PatchRecorder call.
-_deepcopy = copy.deepcopy
 
 # Optional observ integration
 try:
@@ -61,7 +57,7 @@ class PatchRecorder:
                          If not provided, uses the same path. This is needed
                          for sets where add uses "/-" but remove needs "/value".
         """
-        self.patches.append({"op": "add", "path": path, "value": _deepcopy(value)})
+        self.patches.append({"op": "add", "path": path, "value": deepcopy(value)})
         self.reverse_patches.insert(
             0, {"op": "remove", "path": reverse_path if reverse_path else path}
         )
@@ -85,7 +81,7 @@ class PatchRecorder:
             {
                 "op": "add",
                 "path": reverse_path if reverse_path else path,
-                "value": _deepcopy(old_value),
+                "value": deepcopy(old_value),
             },
         )
 
@@ -94,10 +90,10 @@ class PatchRecorder:
         if old_value == new_value:
             return  # Skip no-op replacements
         self.patches.append(
-            {"op": "replace", "path": path, "value": _deepcopy(new_value)}
+            {"op": "replace", "path": path, "value": deepcopy(new_value)}
         )
         self.reverse_patches.insert(
-            0, {"op": "replace", "path": path, "value": _deepcopy(old_value)}
+            0, {"op": "replace", "path": path, "value": deepcopy(old_value)}
         )
 
 
@@ -758,7 +754,7 @@ def produce(
             base = observ_to_raw(base)
 
         # Create a deep copy of the base object
-        draft = _deepcopy(base)
+        draft = deepcopy(base)
 
     # Create a patch recorder
     recorder = PatchRecorder()

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -12,6 +12,10 @@ from typing import Any, Callable, Dict, List, Set, Tuple, Union
 
 from .pointer import Pointer
 
+# Local alias to avoid the `copy` global + `.deepcopy` attribute lookup on
+# every PatchRecorder call.
+_deepcopy = copy.deepcopy
+
 # Optional observ integration
 try:
     from observ import to_raw as observ_to_raw
@@ -57,7 +61,7 @@ class PatchRecorder:
                          If not provided, uses the same path. This is needed
                          for sets where add uses "/-" but remove needs "/value".
         """
-        self.patches.append({"op": "add", "path": path, "value": copy.deepcopy(value)})
+        self.patches.append({"op": "add", "path": path, "value": _deepcopy(value)})
         self.reverse_patches.insert(
             0, {"op": "remove", "path": reverse_path if reverse_path else path}
         )
@@ -81,7 +85,7 @@ class PatchRecorder:
             {
                 "op": "add",
                 "path": reverse_path if reverse_path else path,
-                "value": copy.deepcopy(old_value),
+                "value": _deepcopy(old_value),
             },
         )
 
@@ -90,10 +94,10 @@ class PatchRecorder:
         if old_value == new_value:
             return  # Skip no-op replacements
         self.patches.append(
-            {"op": "replace", "path": path, "value": copy.deepcopy(new_value)}
+            {"op": "replace", "path": path, "value": _deepcopy(new_value)}
         )
         self.reverse_patches.insert(
-            0, {"op": "replace", "path": path, "value": copy.deepcopy(old_value)}
+            0, {"op": "replace", "path": path, "value": _deepcopy(old_value)}
         )
 
 
@@ -754,7 +758,7 @@ def produce(
             base = observ_to_raw(base)
 
         # Create a deep copy of the base object
-        draft = copy.deepcopy(base)
+        draft = _deepcopy(base)
 
     # Create a patch recorder
     recorder = PatchRecorder()

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -38,19 +38,6 @@ def _add_reader_methods(proxy_class, method_names):
         setattr(proxy_class, method_name, _make_reader(method_name))
 
 
-def _snapshot(value: Any) -> Any:
-    """Deepcopy mutable containers so later proxy mutations don't bleed into
-    previously-recorded patches. Primitives are returned as-is."""
-    # Duck-type mirror of the checks used in DictProxy/ListProxy._wrap.
-    if (
-        hasattr(value, "keys")
-        or hasattr(value, "append")
-        or (hasattr(value, "add") and hasattr(value, "discard"))
-    ):
-        return copy.deepcopy(value)
-    return value
-
-
 class PatchRecorder:
     """Records patches as mutations happen on proxy objects."""
 
@@ -70,7 +57,7 @@ class PatchRecorder:
                          If not provided, uses the same path. This is needed
                          for sets where add uses "/-" but remove needs "/value".
         """
-        self.patches.append({"op": "add", "path": path, "value": _snapshot(value)})
+        self.patches.append({"op": "add", "path": path, "value": copy.deepcopy(value)})
         self.reverse_patches.insert(
             0, {"op": "remove", "path": reverse_path if reverse_path else path}
         )
@@ -94,7 +81,7 @@ class PatchRecorder:
             {
                 "op": "add",
                 "path": reverse_path if reverse_path else path,
-                "value": _snapshot(old_value),
+                "value": copy.deepcopy(old_value),
             },
         )
 
@@ -103,10 +90,10 @@ class PatchRecorder:
         if old_value == new_value:
             return  # Skip no-op replacements
         self.patches.append(
-            {"op": "replace", "path": path, "value": _snapshot(new_value)}
+            {"op": "replace", "path": path, "value": copy.deepcopy(new_value)}
         )
         self.reverse_patches.insert(
-            0, {"op": "replace", "path": path, "value": _snapshot(old_value)}
+            0, {"op": "replace", "path": path, "value": copy.deepcopy(old_value)}
         )
 
 

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -38,6 +38,19 @@ def _add_reader_methods(proxy_class, method_names):
         setattr(proxy_class, method_name, _make_reader(method_name))
 
 
+def _snapshot(value: Any) -> Any:
+    """Deepcopy mutable containers so later proxy mutations don't bleed into
+    previously-recorded patches. Primitives are returned as-is."""
+    # Duck-type mirror of the checks used in DictProxy/ListProxy._wrap.
+    if (
+        hasattr(value, "keys")
+        or hasattr(value, "append")
+        or (hasattr(value, "add") and hasattr(value, "discard"))
+    ):
+        return copy.deepcopy(value)
+    return value
+
+
 class PatchRecorder:
     """Records patches as mutations happen on proxy objects."""
 
@@ -57,7 +70,7 @@ class PatchRecorder:
                          If not provided, uses the same path. This is needed
                          for sets where add uses "/-" but remove needs "/value".
         """
-        self.patches.append({"op": "add", "path": path, "value": value})
+        self.patches.append({"op": "add", "path": path, "value": _snapshot(value)})
         self.reverse_patches.insert(
             0, {"op": "remove", "path": reverse_path if reverse_path else path}
         )
@@ -81,7 +94,7 @@ class PatchRecorder:
             {
                 "op": "add",
                 "path": reverse_path if reverse_path else path,
-                "value": old_value,
+                "value": _snapshot(old_value),
             },
         )
 
@@ -89,9 +102,11 @@ class PatchRecorder:
         """Record a replace operation, but only if the value actually changed."""
         if old_value == new_value:
             return  # Skip no-op replacements
-        self.patches.append({"op": "replace", "path": path, "value": new_value})
+        self.patches.append(
+            {"op": "replace", "path": path, "value": _snapshot(new_value)}
+        )
         self.reverse_patches.insert(
-            0, {"op": "replace", "path": path, "value": old_value}
+            0, {"op": "replace", "path": path, "value": _snapshot(old_value)}
         )
 
 

--- a/tests/test_produce_core.py
+++ b/tests/test_produce_core.py
@@ -869,3 +869,51 @@ class TestProxyApiCompleteness:
             f"SetProxy is missing methods from set: {sorted(unhandled)}. "
             f"Either implement them on SetProxy or add to _SET_SKIPPED."
         )
+
+
+class TestPatchSnapshotting:
+    """Patches must snapshot mutable values so later proxy mutations don't
+    silently rewrite earlier patches' stored values."""
+
+    def test_dict_value_mutated_after_assignment_is_snapshotted(self):
+        """Recipe assigns a list, then mutates it. Replay must match result."""
+
+        def recipe(draft):
+            draft["a"] = [1, 2, 3]
+            draft["a"].append(4)
+
+        result, patches, reverse = produce({}, recipe)
+        assert result == {"a": [1, 2, 3, 4]}
+        assert apply({}, patches) == result
+        assert apply(result, reverse) == {}
+
+    def test_list_element_mutated_after_append_is_snapshotted(self):
+        """Recipe appends a dict, then mutates it. Replay must match result."""
+
+        def recipe(draft):
+            draft.append({"x": 1})
+            draft[-1]["x"] = 2
+
+        result, patches, reverse = produce([], recipe)
+        assert result == [{"x": 2}]
+        assert apply([], patches) == result
+        assert apply(result, reverse) == []
+
+    def test_nested_dict_in_list_in_dict_mutation_is_snapshotted(self):
+        """Arbitrarily nested mutation after the parent was added."""
+
+        def recipe(draft):
+            draft["users"] = [{"name": "Alice", "tags": ["py"]}]
+            draft["users"][0]["tags"].append("js")
+            draft["users"].append({"name": "Bob", "tags": ["go"]})
+            draft["users"][1]["tags"][0] = "rust"
+
+        result, patches, reverse = produce({}, recipe)
+        assert result == {
+            "users": [
+                {"name": "Alice", "tags": ["py", "js"]},
+                {"name": "Bob", "tags": ["rust"]},
+            ]
+        }
+        assert apply({}, patches) == result
+        assert apply(result, reverse) == {}


### PR DESCRIPTION
## Summary

`PatchRecorder.record_add` / `record_replace` / `record_remove` stored the raw `value` reference. If the recipe later mutated that container through the proxy, the earlier patch's stored `value` mutated with it, so replaying the patches diverged from the recipe's own result.

The fix is one line per call site: `copy.deepcopy(value)` before storing it in the patch dict, for both the forward `value` and the reverse `old_value`.

## Reproducer (failing on `master`)

```bash
uv run python -c "
from patchdiff import produce, apply
def recipe(draft):
    draft['a'] = [1, 2, 3]
    draft['a'].append(4)
result, patches, _ = produce({}, recipe)
print('result:  ', result)
print('replayed:', apply({}, patches))
assert result == apply({}, patches), 'patches do not reproduce result'
"
```

Output on `master`:

```
result:   {'a': [1, 2, 3, 4]}
replayed: {'a': [1, 2, 3, 4, 4]}
AssertionError: patches do not reproduce result
```

On this branch the assertion passes.

## Regression tests added

In `tests/test_produce_core.py::TestPatchSnapshotting`:

- `test_dict_value_mutated_after_assignment_is_snapshotted` — assigns a list to a dict key then `.append`s to it; verifies both forward and reverse patches replay.
- `test_list_element_mutated_after_append_is_snapshotted` — appends a dict to a list then mutates the appended dict's field via `draft[-1]['x'] = 2`.
- `test_nested_dict_in_list_in_dict_mutation_is_snapshotted` — dict containing a list of dicts; mutates the nested tags lists and dict fields after the parent list was assigned.

All three assert `apply(base, patches) == result` and `apply(result, reverse) == base`.

## Snapshot strategy: B (unconditional deepcopy)

The plan suggested starting with A (deepcopy only containers, decided by duck-typed `hasattr` checks). I tried both and measured. `copy.deepcopy` already has a fast-path for atomic types (registered in `_deepcopy_dispatch`) that just returns the same object — cheaper than three `hasattr` MRO walks. Microbench on mixed primitive/container input: unconditional is ~0.92× the time of gated. The full produce benchmark suite agrees: unconditional matches or beats the gated version on every test (worst regression vs master dropped from +15.6% with gating to +8.9% without). So option B is both simpler and faster here.

(`to_raw` is a different tool — it unwraps an observ reactive proxy to the underlying raw container, but that container is still a shared mutable reference. The bug is about subsequent mutation, which needs an independent copy. `produce()` already calls `to_raw` on the base at entry, so reactive values shouldn't reach the recorder in normal use.)

## Performance: `produce-vs-diff-*` groups

Baseline = `master` @ a9ac89e (saved as `0001`). NOW = this branch.

| Benchmark | Baseline (µs) | NOW (µs) | Δ |
|---|---:|---:|---:|
| `produce_deep_nested_mutation[in_place]` | 10.03 | 10.08 | +0.5% |
| `produce_deep_nested_mutation[copy]` | 33.03 | 32.95 | −0.3% |
| `produce_dict_small_mutations[in_place]` | 12.01 | 12.45 | +3.6% |
| `produce_dict_small_mutations[copy]` | 39.12 | 40.00 | +2.2% |
| `produce_dict_many_mutations[in_place]` | 306.43 | 333.69 | +8.9% |
| `produce_dict_many_mutations[copy]` | 570.89 | 599.24 | +5.0% |
| `produce_list_small_mutations[in_place]` | 7.24 | 7.48 | +3.3% |
| `produce_list_small_mutations[copy]` | 27.01 | 26.99 | −0.0% |
| `produce_list_many_appends[in_place]` | 54.59 | 57.14 | +4.7% |
| `produce_list_many_appends[copy]` | 73.27 | 76.91 | +5.0% |
| `produce_nested_structure[in_place]` | 154.81 | 156.14 | +0.9% |
| `produce_nested_structure[copy]` | 386.66 | 386.23 | −0.1% |
| `produce_set_mutations[in_place]` | 71.73 | 75.61 | +5.4% |
| `produce_set_mutations[copy]` | 175.02 | 178.25 | +1.8% |
| `produce_sparse_mutations_large_object[in_place]` | 509.46 | 507.73 | −0.3% |
| `produce_sparse_mutations_large_object[copy]` | 2462.73 | 2450.46 | −0.5% |

Worst single regression is +8.9% on `dict_many_mutations[in_place]`, well under the 30% threshold from the plan. Most benchmarks are within run-to-run noise.

## Test plan

- [x] `uv run pytest tests/test_produce_core.py -v` — 50 passed (incl. 3 new)
- [x] `uv run pytest -x -q` — 271 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] Reproducer from the plan now succeeds
- [x] `produce-vs-diff-*` benchmarks compared against `master` baseline (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)