### PR TITLE
fix: iapply raises on invalid patch paths

### DIFF
--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -50,8 +50,7 @@ class Pointer:
         key = ""
         parent = None
         cursor = obj
-        tokens = self.tokens
-        if tokens:
+        if tokens := self.tokens:
             # Walk to the parent strictly: any failure here is a path that
             # doesn't exist in the target, and silently landing on a partial
             # parent would let iapply write to the wrong place.

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -50,14 +50,29 @@ class Pointer:
         key = ""
         parent = None
         cursor = obj
-        if tokens := self.tokens:
+        tokens = self.tokens
+        if tokens:
+            # Walk to the parent strictly: any failure here is a path that
+            # doesn't exist in the target, and silently landing on a partial
+            # parent would let iapply write to the wrong place.
+            for key in tokens[:-1]:
+                parent = cursor
+                cursor = parent[key]
+            # The leaf may legitimately not exist (add ops on dicts, list
+            # "-" append) so we tolerate lookup failures there — but only
+            # when the parent is itself a container we can write into.
+            parent = cursor
+            key = tokens[-1]
             try:
-                for key in tokens:
-                    parent = cursor
-                    cursor = parent[key]
-            except (KeyError, TypeError):
-                # KeyError for dicts, TypeError for sets and lists
-                pass
+                cursor = parent[key]
+            except (KeyError, IndexError, TypeError):
+                if not (
+                    hasattr(parent, "keys")
+                    or hasattr(parent, "append")
+                    or hasattr(parent, "add")
+                ):
+                    raise
+                cursor = None
         return parent, key, cursor
 
     def append(self, token: Hashable) -> "Pointer":

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,4 +1,7 @@
+import pytest
+
 from patchdiff import apply, diff
+from patchdiff.pointer import Pointer
 
 
 def test_apply():
@@ -132,3 +135,21 @@ def test_add_remove_list_extended_inverse_leaving_end():
 
     d = apply(b, rops)
     assert a == d
+
+
+def test_apply_raises_on_missing_dict_key():
+    ops = [{"op": "replace", "path": Pointer(["missing", "key"]), "value": 99}]
+    with pytest.raises(KeyError):
+        apply({"present": 1}, ops)
+
+
+def test_apply_raises_on_out_of_range_list_index():
+    ops = [{"op": "replace", "path": Pointer([10, "x"]), "value": 99}]
+    with pytest.raises(IndexError):
+        apply([1, 2, 3], ops)
+
+
+def test_apply_raises_when_traversing_into_primitive():
+    ops = [{"op": "replace", "path": Pointer(["a", "b"]), "value": 99}]
+    with pytest.raises(TypeError):
+        apply({"a": 5}, ops)

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -1,3 +1,5 @@
+import pytest
+
 from patchdiff.pointer import Pointer
 
 
@@ -44,3 +46,18 @@ def test_pointer_eq():
 
 def test_pointer_append():
     assert Pointer([1]).append("foo") == Pointer([1, "foo"])
+
+
+def test_pointer_evaluate_raises_on_missing_dict_key():
+    with pytest.raises(KeyError):
+        Pointer(["missing", "key"]).evaluate({"present": 1})
+
+
+def test_pointer_evaluate_raises_on_out_of_range_list_index():
+    with pytest.raises(IndexError):
+        Pointer([10, "x"]).evaluate([1, 2, 3])
+
+
+def test_pointer_evaluate_raises_when_traversing_into_primitive():
+    with pytest.raises(TypeError):
+        Pointer(["a", "b"]).evaluate({"a": 5})


### PR DESCRIPTION
> **Draft / behavior change — requesting review on direction before merge.**

## Problem

`Pointer.evaluate()` in `patchdiff/pointer.py` swallowed `KeyError`/`TypeError` mid-traversal and returned a partially-walked `(parent, key)` pair. `iapply` then operated on whatever cursor was last reached, which produced:

- **Silent writes to the wrong parent.** A `replace` on `/missing/key` against `{"present": 1}` silently mutated the root dict to `{"present": 1, "missing": 99}` instead of failing.
- **Confusing downstream errors.** Walking into a primitive (`/a/b` where `a` is an `int`) raised `AttributeError: 'int' object has no attribute 'remove'` from deep inside `iapply` instead of a clear traversal error.

Reproducer on `master`:

```python
from patchdiff import apply
from patchdiff.pointer import Pointer

apply({"present": 1}, [{"op": "replace", "path": Pointer(["missing", "key"]), "value": 99}])
# returns {'present': 1, 'missing': 99} — no error
```

## Approach (sketch B from the plan, narrowed)

I went with a hybrid: **strict parent walk, lenient leaf lookup.**

- For tokens up to the parent (`tokens[:-1]`): no `try/except` — let the underlying container's `KeyError` / `IndexError` / `TypeError` propagate naturally.
- For the final leaf token: still tolerate lookup failure (this is the case `add` ops and `Pointer(["-"])` rely on), but only when `parent` is itself a known container (`hasattr` for `keys`/`append`/`add`). If the parent is a primitive, the natural `TypeError` from `parent[key]` propagates.

A pure Plan A (just delete the `try/except`) initially broke 6 valid-path tests:
- `diff()` legitimately produces `add` patches whose leaf key doesn't exist in the source yet (e.g. adding `"c"` to `{"present": 1}`).
- List append uses `Pointer(["-"])`, and `[1, 2, 3]["-"]` raises `TypeError`.

The narrow form preserves both while fixing the silent-wrong-parent bug.

### Callers of `evaluate`

Only one production caller: [patchdiff/apply.py:14](patchdiff/apply.py:14) (`iapply`). Tests reference it but only on valid paths. No external callers depend on the silent behavior.

## Decision points — please pick before merge

1. **Where to raise.** I picked **B (strict in `evaluate`, lenient at leaf)** over **A (raise everywhere, simplify `iapply`)** because pure A breaks valid `add` and list-append patches. An alternative is to keep `evaluate` fully lenient and have `iapply` validate after — happy to switch if you prefer that surface.
2. **Which built-in exception.** I let the underlying container decide: `KeyError` (dict), `IndexError` (list), `TypeError` (primitive / set / type-mismatched index). The plan flagged mixed paths as ambiguous; I think letting the container speak for itself is least surprising.
3. **Opt-out flag (e.g. `ignore_missing=True`).** Not added. The previous silent behavior masked real bugs; I don't think any caller should rely on it. Flagging in case you disagree.

## Tests added

In `tests/test_apply.py`:
- `test_apply_raises_on_missing_dict_key` — asserts `KeyError` for `Pointer(["missing", "key"])` against `{"present": 1}`.
- `test_apply_raises_on_out_of_range_list_index` — asserts `IndexError` for `Pointer([10, "x"])` against `[1, 2, 3]`.
- `test_apply_raises_when_traversing_into_primitive` — asserts `TypeError` for `Pointer(["a", "b"])` against `{"a": 5}`.

In `tests/test_pointer.py` (same three cases at the `evaluate` level):
- `test_pointer_evaluate_raises_on_missing_dict_key` → `KeyError`
- `test_pointer_evaluate_raises_on_out_of_range_list_index` → `IndexError`
- `test_pointer_evaluate_raises_when_traversing_into_primitive` → `TypeError`

## Verification

- `uv run pytest tests/test_apply.py tests/test_pointer.py -v` — all 23 pass (6 new + 17 existing).
- `uv run pytest -x -q` — full suite, 274 passed.
- `uv run ruff check` / `ruff format --check` on changed files — clean. (Pre-existing untracked `benchmarks/profiler.py` has unrelated T201 print warnings; not touched by this PR.)

@berendkleinhaneveld — flagging for direction-check on the three decision points above before this comes out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)