### PR TITLE
perf: use str.replace in Pointer escape/unescape

### DIFF
--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-import re
 from typing import Any, Hashable, Iterable
 
 from .types import Diffable
 
-tilde0_re = re.compile("~0")
-tilde1_re = re.compile("~1")
-tilde_re = re.compile("~")
-slash_re = re.compile("/")
-
 
 def unescape(token: str) -> str:
-    return tilde0_re.sub("~", tilde1_re.sub("/", token))
+    return token.replace("~1", "/").replace("~0", "~")
 
 
 def escape(token: str) -> str:
-    return slash_re.sub("~1", tilde_re.sub("~0", token))
+    return token.replace("~", "~0").replace("/", "~1")
 
 
 class Pointer:

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -1,4 +1,4 @@
-from patchdiff.pointer import Pointer
+from patchdiff.pointer import Pointer, escape, unescape
 
 
 def test_pointer_get():
@@ -44,3 +44,31 @@ def test_pointer_eq():
 
 def test_pointer_append():
     assert Pointer([1]).append("foo") == Pointer([1, "foo"])
+
+
+def test_escape_unescape_roundtrip():
+    # ~01 is the tricky case: escape must produce ~001, not be confused with
+    # the RFC 6901 escape sequence ~0 followed by '1'.
+    tokens = [
+        "",
+        "plain",
+        "has/slash",
+        "has~tilde",
+        "~/mix",
+        "///",
+        "~~~",
+        "~01",
+    ]
+    expected = {
+        "": "",
+        "plain": "plain",
+        "has/slash": "has~1slash",
+        "has~tilde": "has~0tilde",
+        "~/mix": "~0~1mix",
+        "///": "~1~1~1",
+        "~~~": "~0~0~0",
+        "~01": "~001",
+    }
+    for token in tokens:
+        assert escape(token) == expected[token]
+        assert unescape(escape(token)) == token


### PR DESCRIPTION
## Summary

Replaces the regex-based `escape`/`unescape` helpers in `patchdiff/pointer.py` with `str.replace`. For single-character substitutions, `str.replace` is ~3× faster than a compiled regex, and `Pointer.__str__` calls `escape(str(t))` for every token in the pointer — so every `to_json` / `to_str_paths` call benefits.

The four module-level `re.compile` objects (`slash_re`, `tilde_re`, `tilde0_re`, `tilde1_re`) and `import re` are removed. `grep` confirms no other file in the repo imports those names.

## Micro-bench (reproducer from plan)

```python
import timeit
from patchdiff.pointer import escape, unescape
print('escape  100k:', timeit.timeit(lambda: escape('somekey_42'),  number=100_000) * 1000, 'ms')
print('unescape 100k:', timeit.timeit(lambda: unescape('somekey_42'), number=100_000) * 1000, 'ms')
```

| | `escape` 100k | `unescape` 100k |
|---|---|---|
| `master` | 23.1 ms | 23.5 ms |
| this branch | 6.8 ms | 7.5 ms |
| speedup | **3.4×** | **3.1×** |

(Target was ≥2× on `escape`.)

## Macro-bench

`uv run pytest benchmarks/benchmark.py --benchmark-only -k "pointer"` — `pointer-append` and `pointer-evaluate` groups unchanged, as expected (escape only runs on serialization, not append/evaluate):

```
test_pointer_append                  180.88 ns
test_pointer_evaluate_deep_list      1.28 us
test_pointer_evaluate_deep_dict      2.21 us
```

## Correctness

- Full existing test suite passes unchanged (269 tests).
- Added `test_escape_unescape_roundtrip` in `tests/test_pointer.py` covering: `''`, `'plain'`, `'has/slash'`, `'has~tilde'`, `'~/mix'`, `'///'`, `'~~~'`, and the tricky `'~01'` (which must escape to `'~001'`, not be confused with the RFC 6901 `~0` + `'1'` sequence). For each token the test asserts both `escape(t)` matches RFC 6901 and `unescape(escape(t)) == t`.

RFC 6901 escape order (`~` → `~0` before `/` → `~1` on escape; reverse on unescape) is preserved.

## Test plan

- [x] `uv run pytest tests/test_pointer.py -v`
- [x] `uv run pytest -x -q`
- [x] `uv run pytest benchmarks/benchmark.py --benchmark-only -k "pointer"`
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)