### PR TITLE
perf: linear reverse-op construction in diff_dicts/diff_sets

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -149,6 +149,15 @@ def test_dict_diff_nested(benchmark):
     benchmark(diff, a, b)
 
 
+@pytest.mark.benchmark(group="dict-diff")
+@pytest.mark.parametrize("n", [500, 1000, 2000])
+def test_dict_diff_large_common(benchmark, n):
+    """Benchmark: dicts where every key is common and every value changes."""
+    a = {f"k{i}": {"v": i} for i in range(n)}
+    b = {f"k{i}": {"v": i + 1} for i in range(n)}
+    benchmark(diff, a, b)
+
+
 # ========================================
 # Set Diff Benchmarks
 # ========================================

--- a/patchdiff/diff.py
+++ b/patchdiff/diff.py
@@ -135,44 +135,59 @@ def diff_lists(input: List, output: List, ptr: Pointer) -> Tuple[List, List]:
 
 
 def diff_dicts(input: Dict, output: Dict, ptr: Pointer) -> Tuple[List, List]:
-    ops, rops = [], []
+    ops: List = []
+    input_only_rops: List = []
+    output_only_rops: List = []
+    common_rops_chunks: List[List] = []
+
     input_keys = set(input.keys()) if input else set()
     output_keys = set(output.keys()) if output else set()
-    if input_only := input_keys - output_keys:
-        for key in input_only:
-            key_ptr = ptr.append(key)
-            ops.append({"op": "remove", "path": key_ptr})
-            rops.insert(0, {"op": "add", "path": key_ptr, "value": input[key]})
-    if output_only := output_keys - input_keys:
-        for key in output_only:
-            key_ptr = ptr.append(key)
-            ops.append(
-                {
-                    "op": "add",
-                    "path": key_ptr,
-                    "value": output[key],
-                }
-            )
-            rops.insert(0, {"op": "remove", "path": key_ptr})
-    if common := input_keys & output_keys:
-        for key in common:
-            key_ops, key_rops = diff(input[key], output[key], ptr.append(key))
-            ops.extend(key_ops)
-            key_rops.extend(rops)
-            rops = key_rops
+
+    for key in input_keys - output_keys:
+        key_ptr = ptr.append(key)
+        ops.append({"op": "remove", "path": key_ptr})
+        input_only_rops.append({"op": "add", "path": key_ptr, "value": input[key]})
+    input_only_rops.reverse()
+
+    for key in output_keys - input_keys:
+        key_ptr = ptr.append(key)
+        ops.append({"op": "add", "path": key_ptr, "value": output[key]})
+        output_only_rops.append({"op": "remove", "path": key_ptr})
+    output_only_rops.reverse()
+
+    for key in input_keys & output_keys:
+        key_ops, key_rops = diff(input[key], output[key], ptr.append(key))
+        ops.extend(key_ops)
+        if key_rops:
+            common_rops_chunks.append(key_rops)
+
+    # Match the historical insert(0,…) + key_rops.extend(rops) layering:
+    # later common chunks went in front of earlier ones, and the input/output
+    # singletons sat behind them in reverse iteration order.
+    rops: List = []
+    for chunk in reversed(common_rops_chunks):
+        rops.extend(chunk)
+    rops.extend(output_only_rops)
+    rops.extend(input_only_rops)
     return ops, rops
 
 
 def diff_sets(input: Set, output: Set, ptr: Pointer) -> Tuple[List, List]:
-    ops, rops = [], []
-    if input_only := input - output:
-        for value in input_only:
-            ops.append({"op": "remove", "path": ptr.append(value)})
-            rops.insert(0, {"op": "add", "path": ptr.append("-"), "value": value})
-    if output_only := output - input:
-        for value in output_only:
-            ops.append({"op": "add", "path": ptr.append("-"), "value": value})
-            rops.insert(0, {"op": "remove", "path": ptr.append(value)})
+    ops: List = []
+    input_only_rops: List = []
+    output_only_rops: List = []
+
+    for value in input - output:
+        ops.append({"op": "remove", "path": ptr.append(value)})
+        input_only_rops.append({"op": "add", "path": ptr.append("-"), "value": value})
+    input_only_rops.reverse()
+
+    for value in output - input:
+        ops.append({"op": "add", "path": ptr.append("-"), "value": value})
+        output_only_rops.append({"op": "remove", "path": ptr.append(value)})
+    output_only_rops.reverse()
+
+    rops = output_only_rops + input_only_rops
     return ops, rops
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,4 +1,6 @@
-from patchdiff import diff
+import random
+
+from patchdiff import apply, diff
 from patchdiff.pointer import Pointer
 
 
@@ -168,3 +170,58 @@ def test_mixed():
         {"op": "add", "path": Pointer(["a", 3, "-"]), "value": "a"},
         {"op": "remove", "path": Pointer(["c"])},
     ]
+
+
+def _random_dict(rng, n_keys, value_pool):
+    return {f"k{i}": rng.choice(value_pool) for i in range(n_keys)}
+
+
+def _mutate_dict(rng, base, value_pool):
+    result = dict(base)
+    keys = list(result.keys())
+    # Replace
+    for key in rng.sample(keys, k=max(1, len(keys) // 3)):
+        result[key] = rng.choice(value_pool)
+    # Remove
+    for key in rng.sample(keys, k=max(1, len(keys) // 4)):
+        result.pop(key, None)
+    # Add
+    for i in range(max(1, len(keys) // 4)):
+        result[f"new_{i}_{rng.randint(0, 10_000)}"] = rng.choice(value_pool)
+    return result
+
+
+def test_dict_diff_roundtrip_property():
+    rng = random.Random(20260526)
+    value_pool = [
+        0,
+        1,
+        "x",
+        "y",
+        (1, 2),
+        {"nested": 1},
+        [1, 2, 3],
+        {"a", "b"},
+    ]
+    cases = 25
+    for _ in range(cases):
+        n_keys = rng.randint(0, 30)
+        a = _random_dict(rng, n_keys, value_pool)
+        b = _mutate_dict(rng, a, value_pool) if a else _random_dict(rng, 5, value_pool)
+        ops, rops = diff(a, b)
+        assert apply(a, ops) == b
+        assert apply(b, rops) == a
+
+
+def test_set_diff_roundtrip_property():
+    rng = random.Random(20260527)
+    universe = list(range(50)) + [f"s{i}" for i in range(50)]
+    cases = 25
+    for _ in range(cases):
+        size_a = rng.randint(0, 30)
+        size_b = rng.randint(0, 30)
+        a = set(rng.sample(universe, k=size_a))
+        b = set(rng.sample(universe, k=size_b))
+        ops, rops = diff(a, b)
+        assert apply(a, ops) == b
+        assert apply(b, rops) == a


### PR DESCRIPTION
## Summary

`diff_dicts` and `diff_sets` in [patchdiff/diff.py](patchdiff/diff.py) built their reverse-op list with `rops.insert(0, …)` inside loops, and `diff_dicts` further prepended each common-key chunk via `key_rops.extend(rops); rops = key_rops`. Both patterns are O(n²) in the number of keys/values.

This PR replaces them with bucket-based assembly: collect input-only, output-only, and common reverse-op chunks separately, then splice once at the end. Op order is preserved bit-for-bit — all existing tests pass without modification.

## Op-order statement

The op order is **unchanged**. The new code reproduces the exact layering the old `insert(0)` + `key_rops.extend(rops)` pattern produced:

- common chunks in reverse iteration order (later common keys are prepended ahead of earlier ones, matching `key_rops.extend(rops); rops = key_rops`)
- followed by output-only rops in reverse iteration order (matching `insert(0)`)
- followed by input-only rops in reverse iteration order (matching `insert(0)`)

The 13 existing equality-on-rops tests in `tests/test_diff.py` and the 9 apply tests in `tests/test_apply.py` pass without changes.

## Round-trip property tests

Added in [tests/test_diff.py](tests/test_diff.py):

- `test_dict_diff_roundtrip_property` — 25 randomized dict pairs (mixed nested values: ints, strings, tuples, dicts, lists, sets) asserting `apply(a, ops) == b` and `apply(b, rops) == a`.
- `test_set_diff_roundtrip_property` — 25 randomized set pairs asserting the same.

Both pass.

## Performance

Reproducer from the plan (3-run mean, M-series Mac):

| n     | before (master) | after (this PR) | speedup |
|-------|-----------------|-----------------|---------|
|   500 |  0.87 ms        |  0.86 ms        |  1.0×   |
|  1000 |  2.28 ms        |  1.71 ms        |  1.3×   |
|  2000 |  6.80 ms        |  3.36 ms        |  2.0×   |
|  4000 | 22.46 ms        |  7.29 ms        |  3.1×   |

Growth ratio (n → 2n) on the branch:
- 500 → 1000: 2.0×
- 1000 → 2000: 2.0×
- 2000 → 4000: 2.2×

That is the linear shape the plan asked for (was 2.6× / 3.0× / 3.3× on master).

## New benchmark

Added `test_dict_diff_large_common[500|1000|2000]` to [benchmarks/benchmark.py](benchmarks/benchmark.py) so this win is locked in. Branch numbers:

| n    | mean    |
|------|---------|
|  500 |  893 µs |
| 1000 | 1799 µs |
| 2000 | 3677 µs |

## Test plan

- [x] `uv run pytest tests/test_diff.py tests/test_apply.py -v` — 24 passed (22 existing + 2 new round-trip)
- [x] `uv run pytest -x -q` — 270 passed
- [x] `uv run pytest benchmarks/benchmark.py --benchmark-only -k "dict or set"` — passes
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)