### PR TITLE
[draft] discuss: ListProxy.reverse patch minimality

### DIFF
--- a/tests/test_produce_list.py
+++ b/tests/test_produce_list.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from patchdiff import produce
+from patchdiff import apply, produce
 from patchdiff.pointer import Pointer
 
 
@@ -866,6 +866,60 @@ def test_list_reverse_single_element():
 
     assert result == [1]
     assert len(patches) == 0
+
+
+def test_list_reverse_emits_n_patches_for_even_n():
+    """Pin current semantics: reverse emits exactly N replace patches for an
+    N-element list of distinct values when N is even.
+
+    With ``replace`` semantics every position must be written explicitly —
+    dropping the patches for one half of each swap pair would leave those
+    positions untouched on apply. See PR discussion for the trade-off.
+    """
+    base = [1, 2, 3, 4]
+
+    def recipe(draft):
+        draft.reverse()
+
+    _result, patches, _reverse = produce(base, recipe)
+
+    assert len(patches) == 4
+    assert all(p["op"] == "replace" for p in patches)
+    assert {p["path"] for p in patches} == {Pointer([i]) for i in range(4)}
+
+
+def test_list_reverse_emits_n_minus_one_patches_for_odd_n():
+    """Pin current semantics: for odd N the middle element is unchanged and
+    record_replace filters that no-op, so we see N-1 patches."""
+    base = [1, 2, 3, 4, 5]
+
+    def recipe(draft):
+        draft.reverse()
+
+    _result, patches, _reverse = produce(base, recipe)
+
+    assert len(patches) == 4
+    assert {p["path"] for p in patches} == {
+        Pointer([0]),
+        Pointer([1]),
+        Pointer([3]),
+        Pointer([4]),
+    }
+
+
+@pytest.mark.parametrize("n", [0, 1, 2, 3, 4, 5, 10])
+def test_list_reverse_round_trip(n):
+    """Forward and reverse patches both round-trip across a range of sizes."""
+    base = list(range(n))
+
+    def recipe(draft):
+        draft.reverse()
+
+    result, patches, reverse = produce(base, recipe)
+
+    assert result == list(reversed(base))
+    assert apply(base, patches) == result
+    assert apply(result, reverse) == base
 
 
 def test_list_sort_empty():


### PR DESCRIPTION
## Summary

`ListProxy.reverse()` currently emits up to `N` `replace` patches for an `N`-element list. The original code comment frames this as 2× the patches needed (with positions `i` and `N-1-i` treated as a swap pair). This PR pins the current semantics with tests and asks: keep, change, or close?

This PR is **tests only — no production behavior change** — to keep the discussion focused on the design call.

## Patch count, current vs. alternatives

| Shape | Patches for `N=4` (distinct values) | Patches for `N=5` | Round-trips? |
|---|---|---|---|
| Current: `range(N)`, single `replace` per slot | 4 | 4 (middle no-op filtered) | yes |
| Plan sketch: `range(N // 2)`, two `replace`s per swap | 4 | 4 | yes |
| "Drop half" hypothetical | 2 | 2 | **no** |

The "drop half" row is the one the existing in-code comment seems to imagine, but I couldn't make it work. Quick proof on `master`:

```python
from patchdiff import apply
from patchdiff.pointer import Pointer
base = [1, 2, 3, 4]
half = [
    {"op": "replace", "path": Pointer([0]), "value": 4},
    {"op": "replace", "path": Pointer([1]), "value": 3},
]
apply(base, half)  # -> [4, 3, 3, 4], not [4, 3, 2, 1]

swap = [
    {"op": "replace", "path": Pointer([0]), "value": 4},
    {"op": "replace", "path": Pointer([3]), "value": 1},
]
apply(base, swap)  # -> [4, 2, 3, 1], not [4, 3, 2, 1]
```

With `replace` semantics each destination slot needs its own patch — there's no way to make positions `i` and `N-1-i` cover for each other. RFC 6902 has `move`, which could swap with two `move`s via a scratch slot, but `apply.py` here doesn't implement `move` and the plan explicitly excludes new op types.

So the realistic options are both `N` patches, just in different iteration orders. The plan's "minimal" sketch (`range(N // 2)` with two `record_replace` calls per iteration) ends up emitting the same count — the parenthetical in the plan acknowledges this: *"Both positions in the swap need a patch — you can't represent the swap with one replace because the value at j is the missing piece for the patch at i."*

## Consequences for `apply` / memory

Since the patch count is unchanged regardless of which loop shape we pick, there's no measurable `apply` runtime or memory delta between the two iteration styles. The forward and reverse patch lists are the same length and touch the same slots.

## What this PR does

- Adds `test_list_reverse_emits_n_patches_for_even_n` — pins `N` patches for `N=4` with distinct values.
- Adds `test_list_reverse_emits_n_minus_one_patches_for_odd_n` — documents that the odd-`N` middle is filtered to a no-op by `record_replace`.
- Adds `test_list_reverse_round_trip` parametrized over `n ∈ {0, 1, 2, 3, 4, 5, 10}` — forward and reverse both round-trip.
- Imports `apply` in the test module.

No changes to `patchdiff/produce.py`.

## Question for the author

Three reasonable directions:

1. **Land these tests, keep current behavior.** The "redundancy" framing in the existing code comment is misleading — `N` patches is the floor for `replace`-only output, and the current loop already hits it. The pinning tests make that explicit.
2. **Refactor the loop to `range(N // 2)` with two emits per iteration.** Same patch count, arguably more readable ("reverse is `N//2` swaps"). Cosmetic.
3. **Close as won't-fix.** Drop the misleading framing from any code comments, leave the loop as-is.

My weak recommendation is (1): the tests are worth keeping either way, and they document the floor so future readers don't go chasing the same "redundancy" thread.

**Land minimal, keep current, or close as won't-fix?**

## Test plan
- [x] `uv run pytest tests/test_produce_list.py -v` — 84 passed
- [x] `uv run pytest -x -q` — 277 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)