### PR TITLE
Bump version to 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "patchdiff"
-version = "0.3.9"
+version = "0.3.10"
 description = "MIT"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },


### PR DESCRIPTION
This version includes the following:

* ci: Update versions of steps and let setup-uv manage the python version (#40)
* perf: trim common prefix/suffix in diff_lists (#36)
* perf: use str.replace in Pointer escape/unescape (#37)
* fix: produce() snapshots mutable values when recording patches (#34)
* perf: linear reverse-op construction in diff_dicts/diff_sets (#38)
* fix: iapply raises on invalid patch paths (#35)
* fix: to_json mutating caller's ops (#33)