### PR TITLE
Bump version to 0.3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "patchdiff"
-version = "0.3.10"
+version = "0.3.11"
 description = "MIT"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },


### PR DESCRIPTION
This release contains the following change:

* Simplify deepcopy (#42) 
  Bumps observ dependency which fixes a problem with stale proxies being used