### PR TITLE
Modernize CI workflows: update actions, trim steps, speed up jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,17 +5,23 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv and Python 3.14
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.14"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
 
       - name: Install dependencies
         run: uv sync --group observ
@@ -43,11 +49,3 @@ jobs:
               --benchmark-compare-fail=mean:5% \
               --benchmark-save=branch \
               --benchmark-sort=mean
-
-      - name: Upload benchmarks
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: Benchmarks
-          path: .benchmarks/
-          include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,30 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+      - name: Install only ruff
+        run: uv sync --only-group ruff
+      - name: Lint
+        run: uv run --no-sync ruff check
+      - name: Format
+        run: uv run --no-sync ruff format --check
+
   test:
-    name: Lint and test on ${{ matrix.name }}
+    name: Test on ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -31,31 +52,26 @@ jobs:
           - name: Linux py314
             pyversion: "3.14"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install uv and Python ${{ matrix.pyversion }}
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.pyversion }}
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+          cache-suffix: py${{ matrix.pyversion }}
       - name: Install dependencies
         run: uv sync --group observ
-      - name: Lint
-        run: uv run ruff check
-      - name: Format
-        run: uv run ruff format --check
       - name: Test
-        run: uv run pytest -v --cov=patchdiff --cov-report=term-missing --cov-fail-under=100
+        run: uv run --no-sync pytest -v --cov=patchdiff --cov-report=term-missing --cov-fail-under=100
 
   build:
     name: Build and test wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - name: Install uv and Python 3.9
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.9"
-      - name: Install dependencies
-        run: uv sync --group observ
+      - uses: actions/checkout@v7
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Build wheel
         run: uv build
       - name: Twine check
@@ -69,7 +85,7 @@ jobs:
   publish:
     name: Publish to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [test, build]
+    needs: [lint, test, build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi
@@ -78,14 +94,13 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v6
       - name: Download wheel artifact
         uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest-watch",
     "pytest-benchmark",
 ]
+ruff = ["ruff"]
 observ = [
     "observ>=0.18.0",
 ]


### PR DESCRIPTION
Roadmap PR 1 (Track A) — port of observ #182.

- **Bump all actions to latest**: checkout v7, setup-uv v8.3.2 (SHA-pinned), action-gh-release v3 (SHA-pinned); upload-artifact v7 / download-artifact v8 were already current.
- **Enable uv caching** keyed on `pyproject.toml`, with a per-Python-version suffix in the test matrix, so wheels aren't re-downloaded on every run.
- **Split lint/format into a dedicated Lint job** that installs only ruff (new `ruff` dependency group, matching observ's layout), instead of running lint and format six times across the test matrix.
- **Remove unnecessary steps**: `uv sync` in the build job (`uv build` uses an isolated build env), checkout in the publish job (release/publish only need the downloaded dist artifact), and the benchmark artifact upload.
- **Add concurrency groups** so superseded pushes and PR updates cancel in-flight runs (tag builds are never cancelled).

The benchmark guard itself is untouched here — replacing it with observ's noise-robust interleaved design (observ #181/#187) is roadmap PR 2, stacked on this one.

Verified locally: `uv sync --only-group ruff` + `uv run --no-sync ruff check` + `ruff format --check` pass, and both workflow files parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2)_