### PR TITLE
Add property-based round-trip tests and the RFC 6902 conformance corpus

### DIFF
--- a/docs/guide/gotchas.md
+++ b/docs/guide/gotchas.md
@@ -8,6 +8,7 @@ Patchdiff's patches are JSON-patch *compliant* for JSON-shaped data (dicts with 
 * **Tuples and frozensets** are treated as atomic values — they are never diffed into, only replaced wholesale.
 * **Pointer tokens can be non-strings** (integer list indices, set members). They stringify losslessly for lists, but set-member tokens can't be parsed back from a string — see [Serialization](serialization.md#non-json-values).
 * **Only `add`, `remove` and `replace` are emitted.** `move`, `copy` and `test` from RFC 6902 are neither generated nor understood by [`apply`][patchdiff.apply.apply]/[`iapply`][patchdiff.apply.iapply].
+* **Operations on the document root are not supported.** Patches address locations *inside* a container. Diffing two documents of different top-level kinds (say a list against a dict) yields a whole-document `replace` at the root, which `apply`/`iapply` cannot execute — keep the top-level type of your state stable.
 
 If you feed patches to a strict third-party JSON patch implementation, stick to JSON-shaped data and everything lines up.
 

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -78,7 +78,15 @@ class Pointer:
             # parent would let iapply write to the wrong place.
             for key in tokens[:-1]:
                 parent = cursor
-                cursor = parent[key]
+                try:
+                    cursor = parent[key]
+                except TypeError:
+                    # Pointers parsed from strings carry string tokens;
+                    # sequences reject those, so retry list indices as
+                    # integers (iapply does the same at the leaf).
+                    if not hasattr(parent, "append"):
+                        raise
+                    cursor = parent[int(key)]
             # The leaf may legitimately not exist (add ops on dicts, list
             # "-" append) so we tolerate lookup failures there — but only
             # when the parent is itself a container we can write into.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ Homepage = "https://github.com/fork-tongue/patchdiff"
 [dependency-groups]
 dev = [
     "ruff",
+    "hypothesis",
     "pytest",
     "pytest-cov",
     "pytest-watch",

--- a/tests/rfc6902/spec_tests.json
+++ b/tests/rfc6902/spec_tests.json
@@ -1,0 +1,233 @@
+[
+  {
+    "comment": "4.1. add with missing object",
+    "doc": { "q": { "bar": 2 } },
+    "patch": [ {"op": "add", "path": "/a/b", "value": 1} ],
+    "error":
+       "path /a does not exist -- missing objects are not created recursively"
+  },
+
+  {
+    "comment": "A.1.  Adding an Object Member",
+    "doc": {
+  "foo": "bar"
+},
+    "patch": [
+  { "op": "add", "path": "/baz", "value": "qux" }
+],
+    "expected": {
+  "baz": "qux",
+  "foo": "bar"
+}
+  },
+
+  {
+    "comment": "A.2.  Adding an Array Element",
+    "doc": {
+  "foo": [ "bar", "baz" ]
+},
+    "patch": [
+  { "op": "add", "path": "/foo/1", "value": "qux" }
+],
+    "expected": {
+  "foo": [ "bar", "qux", "baz" ]
+}
+  },
+
+  {
+    "comment": "A.3.  Removing an Object Member",
+    "doc": {
+  "baz": "qux",
+  "foo": "bar"
+},
+    "patch": [
+  { "op": "remove", "path": "/baz" }
+],
+    "expected": {
+  "foo": "bar"
+}
+  },
+
+  {
+    "comment": "A.4.  Removing an Array Element",
+    "doc": {
+  "foo": [ "bar", "qux", "baz" ]
+},
+    "patch": [
+  { "op": "remove", "path": "/foo/1" }
+],
+    "expected": {
+  "foo": [ "bar", "baz" ]
+}
+  },
+
+  {
+    "comment": "A.5.  Replacing a Value",
+    "doc": {
+  "baz": "qux",
+  "foo": "bar"
+},
+    "patch": [
+  { "op": "replace", "path": "/baz", "value": "boo" }
+],
+    "expected": {
+  "baz": "boo",
+  "foo": "bar"
+}
+  },
+
+  {
+    "comment": "A.6.  Moving a Value",
+    "doc": {
+  "foo": {
+    "bar": "baz",
+    "waldo": "fred"
+  },
+  "qux": {
+    "corge": "grault"
+  }
+},
+    "patch": [
+  { "op": "move", "from": "/foo/waldo", "path": "/qux/thud" }
+],
+    "expected": {
+  "foo": {
+    "bar": "baz"
+  },
+  "qux": {
+    "corge": "grault",
+    "thud": "fred"
+  }
+}
+  },
+
+  {
+    "comment": "A.7.  Moving an Array Element",
+    "doc": {
+  "foo": [ "all", "grass", "cows", "eat" ]
+},
+    "patch": [
+  { "op": "move", "from": "/foo/1", "path": "/foo/3" }
+],
+    "expected": {
+  "foo": [ "all", "cows", "eat", "grass" ]
+}
+
+  },
+
+  {
+    "comment": "A.8.  Testing a Value: Success",
+    "doc": {
+  "baz": "qux",
+  "foo": [ "a", 2, "c" ]
+},
+    "patch": [
+  { "op": "test", "path": "/baz", "value": "qux" },
+  { "op": "test", "path": "/foo/1", "value": 2 }
+],
+    "expected": {
+     "baz": "qux",
+     "foo": [ "a", 2, "c" ]
+    }
+  },
+
+  {
+    "comment": "A.9.  Testing a Value: Error",
+    "doc": {
+  "baz": "qux"
+},
+    "patch": [
+  { "op": "test", "path": "/baz", "value": "bar" }
+],
+    "error": "string not equivalent"
+  },
+
+  {
+    "comment": "A.10.  Adding a nested Member Object",
+    "doc": {
+  "foo": "bar"
+},
+    "patch": [
+  { "op": "add", "path": "/child", "value": { "grandchild": { } } }
+],
+    "expected": {
+  "foo": "bar",
+  "child": {
+    "grandchild": {
+    }
+  }
+}
+  },
+
+  {
+    "comment": "A.11.  Ignoring Unrecognized Elements",
+    "doc": {
+  "foo":"bar"
+},
+    "patch": [
+  { "op": "add", "path": "/baz", "value": "qux", "xyz": 123 }
+],
+    "expected": {
+  "foo":"bar",
+  "baz":"qux"
+}
+  },
+
+ {
+    "comment": "A.12.  Adding to a Non-existent Target",
+    "doc": {
+  "foo": "bar"
+},
+    "patch": [
+  { "op": "add", "path": "/baz/bat", "value": "qux" }
+],
+    "error": "add to a non-existent target"
+  },
+
+ {
+    "comment": "A.13 Invalid JSON Patch Document",
+    "doc": {
+     "foo": "bar"
+    },
+    "patch": [
+  { "op": "add", "path": "/baz", "value": "qux", "op": "remove" }
+],
+    "error": "operation has two 'op' members",
+    "disabled": true
+  },
+
+  {
+    "comment": "A.14. ~ Escape Ordering",
+    "doc": {
+       "/": 9,
+       "~1": 10
+    },
+    "patch": [{"op": "test", "path": "/~01", "value": 10}],
+    "expected": {
+       "/": 9,
+       "~1": 10
+    }
+  },
+
+  {
+    "comment": "A.15. Comparing Strings and Numbers",
+    "doc": {
+       "/": 9,
+       "~1": 10
+    },
+    "patch": [{"op": "test", "path": "/~01", "value": "10"}],
+    "error": "number is not equal to string"
+  },
+
+  {
+    "comment": "A.16. Adding an Array Value",
+    "doc": {
+       "foo": ["bar"]
+    },
+    "patch": [{ "op": "add", "path": "/foo/-", "value": ["abc", "def"] }],
+    "expected": {
+      "foo": ["bar", ["abc", "def"]]
+    }
+  }
+
+]

--- a/tests/rfc6902/tests.json
+++ b/tests/rfc6902/tests.json
@@ -1,0 +1,500 @@
+[
+    { "comment": "empty list, empty docs",
+      "doc": {},
+      "patch": [],
+      "expected": {} },
+
+    { "comment": "empty patch list",
+      "doc": {"foo": 1},
+      "patch": [],
+      "expected": {"foo": 1} },
+
+    { "comment": "rearrangements OK?",
+      "doc": {"foo": 1, "bar": 2},
+      "patch": [],
+      "expected": {"bar":2, "foo": 1} },
+
+    { "comment": "rearrangements OK?  How about one level down ... array",
+      "doc": [{"foo": 1, "bar": 2}],
+      "patch": [],
+      "expected": [{"bar":2, "foo": 1}] },
+
+    { "comment": "rearrangements OK?  How about one level down...",
+      "doc": {"foo":{"foo": 1, "bar": 2}},
+      "patch": [],
+      "expected": {"foo":{"bar":2, "foo": 1}} },
+
+    { "comment": "add replaces any existing field",
+      "doc": {"foo": null},
+      "patch": [{"op": "add", "path": "/foo", "value":1}],
+      "expected": {"foo": 1} },
+
+    { "comment": "toplevel array",
+      "doc": [],
+      "patch": [{"op": "add", "path": "/0", "value": "foo"}],
+      "expected": ["foo"] },
+
+    { "comment": "toplevel array, no change",
+      "doc": ["foo"],
+      "patch": [],
+      "expected": ["foo"] },
+
+    { "comment": "toplevel object, numeric string",
+      "doc": {},
+      "patch": [{"op": "add", "path": "/foo", "value": "1"}],
+      "expected": {"foo":"1"} },
+
+    { "comment": "toplevel object, integer",
+      "doc": {},
+      "patch": [{"op": "add", "path": "/foo", "value": 1}],
+      "expected": {"foo":1} },
+
+    { "comment": "Toplevel scalar values OK?",
+      "doc": "foo",
+      "patch": [{"op": "replace", "path": "", "value": "bar"}],
+      "expected": "bar",
+      "disabled": true },
+
+    { "comment": "replace object document with array document?",
+      "doc": {},
+      "patch": [{"op": "add", "path": "", "value": []}],
+      "expected": [] },
+
+    { "comment": "replace array document with object document?",
+      "doc": [],
+      "patch": [{"op": "add", "path": "", "value": {}}],
+      "expected": {} },
+
+    { "comment": "append to root array document?",
+      "doc": [],
+      "patch": [{"op": "add", "path": "/-", "value": "hi"}],
+      "expected": ["hi"] },
+
+    { "comment": "Add, / target",
+      "doc": {},
+      "patch": [ {"op": "add", "path": "/", "value":1 } ],
+      "expected": {"":1} },
+
+    { "comment": "Add, /foo/ deep target (trailing slash)",
+      "doc": {"foo": {}},
+      "patch": [ {"op": "add", "path": "/foo/", "value":1 } ],
+      "expected": {"foo":{"": 1}} },
+
+    { "comment": "Add composite value at top level",
+      "doc": {"foo": 1},
+      "patch": [{"op": "add", "path": "/bar", "value": [1, 2]}],
+      "expected": {"foo": 1, "bar": [1, 2]} },
+
+    { "comment": "Add into composite value",
+      "doc": {"foo": 1, "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "add", "path": "/baz/0/foo", "value": "world"}],
+      "expected": {"foo": 1, "baz": [{"qux": "hello", "foo": "world"}]} },
+
+    { "doc": {"bar": [1, 2]},
+      "patch": [{"op": "add", "path": "/bar/8", "value": "5"}],
+      "error": "Out of bounds (upper)" },
+
+    { "doc": {"bar": [1, 2]},
+      "patch": [{"op": "add", "path": "/bar/-1", "value": "5"}],
+      "error": "Out of bounds (lower)" },
+
+    { "doc": {"foo": 1},
+      "patch": [{"op": "add", "path": "/bar", "value": true}],
+      "expected": {"foo": 1, "bar": true} },
+
+    { "doc": {"foo": 1},
+      "patch": [{"op": "add", "path": "/bar", "value": false}],
+      "expected": {"foo": 1, "bar": false} },
+
+    { "doc": {"foo": 1},
+      "patch": [{"op": "add", "path": "/bar", "value": null}],
+      "expected": {"foo": 1, "bar": null} },
+
+    { "comment": "0 can be an array index or object element name",
+      "doc": {"foo": 1},
+      "patch": [{"op": "add", "path": "/0", "value": "bar"}],
+      "expected": {"foo": 1, "0": "bar" } },
+
+    { "doc": ["foo"],
+      "patch": [{"op": "add", "path": "/1", "value": "bar"}],
+      "expected": ["foo", "bar"] },
+
+    { "doc": ["foo", "sil"],
+      "patch": [{"op": "add", "path": "/1", "value": "bar"}],
+      "expected": ["foo", "bar", "sil"] },
+
+    { "doc": ["foo", "sil"],
+      "patch": [{"op": "add", "path": "/0", "value": "bar"}],
+      "expected": ["bar", "foo", "sil"] },
+
+    { "comment": "push item to array via last index + 1",
+      "doc": ["foo", "sil"],
+      "patch": [{"op":"add", "path": "/2", "value": "bar"}],
+      "expected": ["foo", "sil", "bar"] },
+
+    { "comment": "add item to array at index > length should fail",
+      "doc": ["foo", "sil"],
+      "patch": [{"op":"add", "path": "/3", "value": "bar"}],
+      "error": "index is greater than number of items in array" },
+
+    { "comment": "test against implementation-specific numeric parsing",
+      "doc": {"1e0": "foo"},
+      "patch": [{"op": "test", "path": "/1e0", "value": "foo"}],
+      "expected": {"1e0": "foo"} },
+
+    { "comment": "test with bad number should fail",
+      "doc": ["foo", "bar"],
+      "patch": [{"op": "test", "path": "/1e0", "value": "bar"}],
+      "error": "test op shouldn't get array element 1" },
+
+    { "doc": ["foo", "sil"],
+      "patch": [{"op": "add", "path": "/bar", "value": 42}],
+      "error": "Object operation on array target" },
+
+    { "doc": ["foo", "sil"],
+      "patch": [{"op": "add", "path": "/1", "value": ["bar", "baz"]}],
+      "expected": ["foo", ["bar", "baz"], "sil"],
+      "comment": "value in array add not flattened" },
+
+    { "doc": {"foo": 1, "bar": [1, 2, 3, 4]},
+      "patch": [{"op": "remove", "path": "/bar"}],
+      "expected": {"foo": 1} },
+
+    { "doc": {"foo": 1, "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "remove", "path": "/baz/0/qux"}],
+      "expected": {"foo": 1, "baz": [{}]} },
+
+    { "doc": {"foo": 1, "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "replace", "path": "/foo", "value": [1, 2, 3, 4]}],
+      "expected": {"foo": [1, 2, 3, 4], "baz": [{"qux": "hello"}]} },
+
+    { "doc": {"foo": [1, 2, 3, 4], "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "replace", "path": "/baz/0/qux", "value": "world"}],
+      "expected": {"foo": [1, 2, 3, 4], "baz": [{"qux": "world"}]} },
+
+    { "doc": ["foo"],
+      "patch": [{"op": "replace", "path": "/0", "value": "bar"}],
+      "expected": ["bar"] },
+
+    { "doc": [""],
+      "patch": [{"op": "replace", "path": "/0", "value": 0}],
+      "expected": [0] },
+
+    { "doc": [""],
+      "patch": [{"op": "replace", "path": "/0", "value": true}],
+      "expected": [true] },
+
+    { "doc": [""],
+      "patch": [{"op": "replace", "path": "/0", "value": false}],
+      "expected": [false] },
+
+    { "doc": [""],
+      "patch": [{"op": "replace", "path": "/0", "value": null}],
+      "expected": [null] },
+
+    { "doc": ["foo", "sil"],
+      "patch": [{"op": "replace", "path": "/1", "value": ["bar", "baz"]}],
+      "expected": ["foo", ["bar", "baz"]],
+      "comment": "value in array replace not flattened" },
+
+    { "comment": "replace whole document",
+      "doc": {"foo": "bar"},
+      "patch": [{"op": "replace", "path": "", "value": {"baz": "qux"}}],
+      "expected": {"baz": "qux"} },
+
+    { "comment": "test replace with missing parent key should fail",
+      "doc": {"bar": "baz"},
+      "patch": [{"op": "replace", "path": "/foo/bar", "value": false}],
+      "error": "replace op should fail with missing parent key" },
+
+    { "comment": "spurious patch properties",
+      "doc": {"foo": 1},
+      "patch": [{"op": "test", "path": "/foo", "value": 1, "spurious": 1}],
+      "expected": {"foo": 1} },
+
+    { "doc": {"foo": null},
+      "patch": [{"op": "test", "path": "/foo", "value": null}],
+      "expected": {"foo": null},
+      "comment": "null value should be valid obj property" },
+
+    { "doc": {"foo": null},
+      "patch": [{"op": "replace", "path": "/foo", "value": "truthy"}],
+      "expected": {"foo": "truthy"},
+      "comment": "null value should be valid obj property to be replaced with something truthy" },
+
+    { "doc": {"foo": null},
+      "patch": [{"op": "move", "from": "/foo", "path": "/bar"}],
+      "expected": {"bar": null},
+      "comment": "null value should be valid obj property to be moved" },
+
+    { "doc": {"foo": null},
+      "patch": [{"op": "copy", "from": "/foo", "path": "/bar"}],
+      "expected": {"foo": null, "bar": null},
+      "comment": "null value should be valid obj property to be copied" },
+
+    { "doc": {"foo": null},
+      "patch": [{"op": "remove", "path": "/foo"}],
+      "expected": {},
+      "comment": "null value should be valid obj property to be removed" },
+
+    { "doc": {"foo": "bar"},
+      "patch": [{"op": "replace", "path": "/foo", "value": null}],
+      "expected": {"foo": null},
+      "comment": "null value should still be valid obj property replace other value" },
+
+    { "doc": {"foo": {"foo": 1, "bar": 2}},
+      "patch": [{"op": "test", "path": "/foo", "value": {"bar": 2, "foo": 1}}],
+      "expected": {"foo": {"foo": 1, "bar": 2}},
+      "comment": "test should pass despite rearrangement" },
+
+    { "doc": {"foo": [{"foo": 1, "bar": 2}]},
+      "patch": [{"op": "test", "path": "/foo", "value": [{"bar": 2, "foo": 1}]}],
+      "expected": {"foo": [{"foo": 1, "bar": 2}]},
+      "comment": "test should pass despite (nested) rearrangement" },
+
+    { "doc": {"foo": {"bar": [1, 2, 5, 4]}},
+      "patch": [{"op": "test", "path": "/foo", "value": {"bar": [1, 2, 5, 4]}}],
+      "expected": {"foo": {"bar": [1, 2, 5, 4]}},
+      "comment": "test should pass - no error" },
+
+    { "doc": {"foo": {"bar": [1, 2, 5, 4]}},
+      "patch": [{"op": "test", "path": "/foo", "value": [1, 2]}],
+      "error": "test op should fail" },
+
+    { "comment": "Whole document",
+      "doc": { "foo": 1 },
+      "patch": [{"op": "test", "path": "", "value": {"foo": 1}}],
+      "disabled": true },
+
+    { "comment": "Empty-string element",
+      "doc": { "": 1 },
+      "patch": [{"op": "test", "path": "/", "value": 1}],
+      "expected": { "": 1 } },
+
+    { "doc": {
+            "foo": ["bar", "baz"],
+            "": 0,
+            "a/b": 1,
+            "c%d": 2,
+            "e^f": 3,
+            "g|h": 4,
+            "i\\j": 5,
+            "k\"l": 6,
+            " ": 7,
+            "m~n": 8
+            },
+      "patch": [{"op": "test", "path": "/foo", "value": ["bar", "baz"]},
+                {"op": "test", "path": "/foo/0", "value": "bar"},
+                {"op": "test", "path": "/", "value": 0},
+                {"op": "test", "path": "/a~1b", "value": 1},
+                {"op": "test", "path": "/c%d", "value": 2},
+                {"op": "test", "path": "/e^f", "value": 3},
+                {"op": "test", "path": "/g|h", "value": 4},
+                {"op": "test", "path":  "/i\\j", "value": 5},
+                {"op": "test", "path": "/k\"l", "value": 6},
+                {"op": "test", "path": "/ ", "value": 7},
+                {"op": "test", "path": "/m~0n", "value": 8}],
+      "expected": {
+            "": 0,
+            " ": 7,
+            "a/b": 1,
+            "c%d": 2,
+            "e^f": 3,
+            "foo": [
+                "bar",
+                "baz"
+            ],
+            "g|h": 4,
+            "i\\j": 5,
+            "k\"l": 6,
+            "m~n": 8
+        }
+    },
+    { "comment": "Move to same location has no effect",
+      "doc": {"foo": 1},
+      "patch": [{"op": "move", "from": "/foo", "path": "/foo"}],
+      "expected": {"foo": 1} },
+
+    { "doc": {"foo": 1, "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "move", "from": "/foo", "path": "/bar"}],
+      "expected": {"baz": [{"qux": "hello"}], "bar": 1} },
+
+    { "doc": {"baz": [{"qux": "hello"}], "bar": 1},
+      "patch": [{"op": "move", "from": "/baz/0/qux", "path": "/baz/1"}],
+      "expected": {"baz": [{}, "hello"], "bar": 1} },
+
+    { "doc": {"baz": [{"qux": "hello"}], "bar": 1},
+      "patch": [{"op": "copy", "from": "/baz/0", "path": "/boo"}],
+      "expected": {"baz":[{"qux":"hello"}],"bar":1,"boo":{"qux":"hello"}} },
+
+    { "comment": "replacing the root of the document is possible with add",
+      "doc": {"foo": "bar"},
+      "patch": [{"op": "add", "path": "", "value": {"baz": "qux"}}],
+      "expected": {"baz":"qux"}},
+
+    { "comment": "Adding to \"/-\" adds to the end of the array",
+      "doc": [ 1, 2 ],
+      "patch": [ { "op": "add", "path": "/-", "value": { "foo": [ "bar", "baz" ] } } ],
+      "expected": [ 1, 2, { "foo": [ "bar", "baz" ] } ]},
+
+    { "comment": "Adding to \"/-\" adds to the end of the array, even n levels down",
+      "doc": [ 1, 2, [ 3, [ 4, 5 ] ] ],
+      "patch": [ { "op": "add", "path": "/2/1/-", "value": { "foo": [ "bar", "baz" ] } } ],
+      "expected": [ 1, 2, [ 3, [ 4, 5, { "foo": [ "bar", "baz" ] } ] ] ]},
+
+    { "comment": "test remove with bad number should fail",
+      "doc": {"foo": 1, "baz": [{"qux": "hello"}]},
+      "patch": [{"op": "remove", "path": "/baz/1e0/qux"}],
+      "error": "remove op shouldn't remove from array with bad number" },
+
+    { "comment": "test remove on array",
+      "doc": [1, 2, 3, 4],
+      "patch": [{"op": "remove", "path": "/0"}],
+      "expected": [2, 3, 4] },
+
+    { "comment": "test repeated removes",
+      "doc": [1, 2, 3, 4],
+      "patch": [{ "op": "remove", "path": "/1" },
+                { "op": "remove", "path": "/2" }],
+      "expected": [1, 3] },
+
+    { "comment": "test remove with bad index should fail",
+      "doc": [1, 2, 3, 4],
+      "patch": [{"op": "remove", "path": "/1e0"}],
+      "error": "remove op shouldn't remove from array with bad number" },
+
+    { "comment": "test replace with bad number should fail",
+      "doc": [""],
+      "patch": [{"op": "replace", "path": "/1e0", "value": false}],
+      "error": "replace op shouldn't replace in array with bad number" },
+
+    { "comment": "test copy with bad number should fail",
+      "doc": {"baz": [1,2,3], "bar": 1},
+      "patch": [{"op": "copy", "from": "/baz/1e0", "path": "/boo"}],
+      "error": "copy op shouldn't work with bad number" },
+
+    { "comment": "test move with bad number should fail",
+      "doc": {"foo": 1, "baz": [1,2,3,4]},
+      "patch": [{"op": "move", "from": "/baz/1e0", "path": "/foo"}],
+      "error": "move op shouldn't work with bad number" },
+
+    { "comment": "test add with bad number should fail",
+      "doc": ["foo", "sil"],
+      "patch": [{"op": "add", "path": "/1e0", "value": "bar"}],
+      "error": "add op shouldn't add to array with bad number" },
+
+    { "comment": "missing 'path' parameter",
+      "doc": {},
+      "patch": [ { "op": "add", "value": "bar" } ],
+      "error": "missing 'path' parameter" },
+
+    { "comment": "'path' parameter with null value",
+      "doc": {},
+      "patch": [ { "op": "add", "path": null, "value": "bar" } ],
+      "error": "null is not valid value for 'path'" },
+
+    { "comment": "invalid JSON Pointer token",
+      "doc": {},
+      "patch": [ { "op": "add", "path": "foo", "value": "bar" } ],
+      "error": "JSON Pointer should start with a slash" },
+
+    { "comment": "missing 'value' parameter to add",
+      "doc": [ 1 ],
+      "patch": [ { "op": "add", "path": "/-" } ],
+      "error": "missing 'value' parameter" },
+
+    { "comment": "missing 'value' parameter to replace",
+      "doc": [ 1 ],
+      "patch": [ { "op": "replace", "path": "/0" } ],
+      "error": "missing 'value' parameter" },
+
+    { "comment": "missing 'value' parameter to test",
+      "doc": [ null ],
+      "patch": [ { "op": "test", "path": "/0" } ],
+      "error": "missing 'value' parameter" },
+
+    { "comment": "missing value parameter to test - where undef is falsy",
+      "doc": [ false ],
+      "patch": [ { "op": "test", "path": "/0" } ],
+      "error": "missing 'value' parameter" },
+
+    { "comment": "missing from parameter to copy",
+      "doc": [ 1 ],
+      "patch": [ { "op": "copy", "path": "/-" } ],
+      "error": "missing 'from' parameter" },
+
+    { "comment": "missing from location to copy",
+      "doc": { "foo": 1 },
+      "patch": [ { "op": "copy", "from": "/bar", "path": "/foo" } ],
+      "error": "missing 'from' location" },
+
+    { "comment": "missing from parameter to move",
+      "doc": { "foo": 1 },
+      "patch": [ { "op": "move", "path": "" } ],
+      "error": "missing 'from' parameter" },
+
+    { "comment": "missing from location to move",
+      "doc": { "foo": 1 },
+      "patch": [ { "op": "move", "from": "/bar", "path": "/foo" } ],
+      "error": "missing 'from' location" },
+
+    { "comment": "duplicate ops",
+      "doc": { "foo": "bar" },
+      "patch": [ { "op": "add", "path": "/baz", "value": "qux",
+                   "op": "move", "from":"/foo" } ],
+      "error": "patch has two 'op' members",
+      "disabled": true },
+
+    { "comment": "unrecognized op should fail",
+      "doc": {"foo": 1},
+      "patch": [{"op": "spam", "path": "/foo", "value": 1}],
+      "error": "Unrecognized op 'spam'" },
+
+    { "comment": "test with bad array number that has leading zeros",
+      "doc": ["foo", "bar"],
+      "patch": [{"op": "test", "path": "/00", "value": "foo"}],
+      "error": "test op should reject the array value, it has leading zeros" },
+
+    { "comment": "test with bad array number that has leading zeros",
+      "doc": ["foo", "bar"],
+      "patch": [{"op": "test", "path": "/01", "value": "bar"}],
+      "error": "test op should reject the array value, it has leading zeros" },
+
+    { "comment": "Removing nonexistent field",
+      "doc": {"foo" : "bar"},
+      "patch": [{"op": "remove", "path": "/baz"}],
+      "error": "removing a nonexistent field should fail" },
+
+    { "comment": "Removing deep nonexistent path",
+      "doc": {"foo" : "bar"},
+      "patch": [{"op": "remove", "path": "/missing1/missing2"}],
+      "error": "removing a nonexistent field should fail" },
+
+    { "comment": "Removing nonexistent index",
+      "doc": ["foo", "bar"],
+      "patch": [{"op": "remove", "path": "/2"}],
+      "error": "removing a nonexistent index should fail" },
+
+    { "comment": "Patch with different capitalisation than doc",
+       "doc": {"foo":"bar"},
+       "patch": [{"op": "add", "path": "/FOO", "value": "BAR"}],
+       "expected": {"foo": "bar", "FOO": "BAR"} },
+
+    { "comment": "test copy object then change destination",
+      "doc": {"foo": {"bar": {"baz": [{"boo": "net"}]}}},
+      "patch": [
+        {"op": "copy", "from": "/foo", "path": "/bak"},
+        {"op": "replace", "path": "/bak/bar/baz/0/boo", "value": "qux"}
+      ],
+      "expected": {"foo": {"bar": {"baz": [{"boo": "net"}]}}, "bak": {"bar": {"baz": [{"boo":"qux"}]}}} },
+
+    { "comment": "test copy object then change source",
+      "doc": {"foo": {"bar": {"baz": [{"boo": "net"}]}}},
+      "patch": [
+        {"op": "copy", "from": "/foo", "path": "/bak"},
+        {"op": "replace", "path": "/foo/bar/baz/0/boo", "value": "qux"}
+      ],
+      "expected": {"foo": {"bar": {"baz": [{"boo": "qux"}]}}, "bak": {"bar": {"baz": [{"boo":"net"}]}}}
+    }
+
+]

--- a/tests/test_pointer.py
+++ b/tests/test_pointer.py
@@ -89,3 +89,24 @@ def test_pointer_evaluate_raises_on_out_of_range_list_index():
 def test_pointer_evaluate_raises_when_traversing_into_primitive():
     with pytest.raises(TypeError):
         Pointer(["a", "b"]).evaluate({"a": 5})
+
+
+def test_pointer_evaluate_raises_when_traversing_primitive_mid_path():
+    with pytest.raises(TypeError):
+        Pointer(["a", "b", "c"]).evaluate({"a": 5})
+
+
+def test_parsed_pointer_evaluates_through_lists():
+    # Pointers parsed from strings carry string tokens; evaluate must
+    # convert them to list indices while walking to the parent, or
+    # serialized patches with nested-list paths cannot be applied.
+    obj = {"baz": [{"qux": "hello"}]}
+    parent, key, value = Pointer.from_str("/baz/0/qux").evaluate(obj)
+    assert parent is obj["baz"][0]
+    assert key == "qux"
+    assert value == "hello"
+
+
+def test_parsed_pointer_evaluate_raises_on_non_numeric_list_token():
+    with pytest.raises(ValueError):
+        Pointer.from_str("/a/foo/b").evaluate({"a": [{"b": 1}]})

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,165 @@
+"""Property-based tests of patchdiff's core promises.
+
+Hypothesis generates arbitrary nested structures (dicts, lists, sets,
+tuples, frozensets and scalars) and verifies the invariants the rest of
+the test suite can only spot-check:
+
+* ``diff`` + ``apply`` round-trips in both directions, for any pair of
+  structures.
+* ``apply`` never mutates its input; ``iapply`` mutates exactly its
+  input and returns the same object.
+* Serialization is lossless for JSON-shaped data: operations survive
+  ``to_json`` → ``json.loads`` → ``Pointer.from_str`` and still apply
+  correctly, in both directions.
+* Pointer string rendering and token escaping round-trip.
+"""
+
+import json
+from copy import deepcopy
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from patchdiff import apply, diff, iapply, to_json
+from patchdiff.pointer import Pointer, escape, unescape
+
+# Scalars that are hashable, so they can double as set members.
+hashable_scalars = (
+    st.none()
+    | st.booleans()
+    | st.integers()
+    | st.floats(allow_nan=False)  # NaN != NaN breaks equality-based diffing
+    | st.text()
+)
+
+# Tuples and frozensets are treated as atomic values by diff(); they stay
+# in the value mix to pin that behavior.
+atoms = (
+    hashable_scalars
+    | st.tuples(hashable_scalars, hashable_scalars)
+    | st.frozensets(hashable_scalars, max_size=3)
+)
+
+values = st.recursive(
+    atoms,
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(st.text(), children, max_size=4)
+        | st.sets(hashable_scalars, max_size=4)
+    ),
+    max_leaves=25,
+)
+
+# Top-level structures must be containers (patches address locations
+# *inside* the document) and pairs must share their top-level kind:
+# diffing e.g. a list against a dict yields a whole-document replace at
+# the root, which apply/iapply cannot execute (pinned explicitly in
+# test_mixed_kind_roots_are_a_known_limitation below).
+diffable_pairs = (
+    st.tuples(st.lists(values, max_size=6), st.lists(values, max_size=6))
+    | st.tuples(
+        st.dictionaries(st.text(), values, max_size=6),
+        st.dictionaries(st.text(), values, max_size=6),
+    )
+    | st.tuples(
+        st.sets(hashable_scalars, max_size=6),
+        st.sets(hashable_scalars, max_size=6),
+    )
+)
+
+diffables = (
+    st.lists(values, max_size=6)
+    | st.dictionaries(st.text(), values, max_size=6)
+    | st.sets(hashable_scalars, max_size=6)
+)
+
+# The JSON-shaped subset, for which to_json is lossless.
+json_values = st.recursive(
+    hashable_scalars,
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(st.text(), children, max_size=4)
+    ),
+    max_leaves=25,
+)
+json_diffable_pairs = st.tuples(
+    st.lists(json_values, max_size=6), st.lists(json_values, max_size=6)
+) | st.tuples(
+    st.dictionaries(st.text(), json_values, max_size=6),
+    st.dictionaries(st.text(), json_values, max_size=6),
+)
+
+
+@given(pair=diffable_pairs)
+def test_diff_apply_round_trip(pair):
+    a, b = pair
+    ops, reverse_ops = diff(a, b)
+    assert apply(a, ops) == b
+    assert apply(b, reverse_ops) == a
+
+
+@given(a=diffables)
+def test_diff_of_equal_objects_is_empty(a):
+    assert diff(a, deepcopy(a)) == ([], [])
+
+
+@given(pair=diffable_pairs)
+def test_apply_leaves_input_untouched(pair):
+    a, b = pair
+    ops, _ = diff(a, b)
+    snapshot = deepcopy(a)
+    apply(a, ops)
+    assert a == snapshot
+
+
+@given(pair=diffable_pairs)
+def test_iapply_mutates_input_in_place(pair):
+    a, b = pair
+    ops, _ = diff(a, b)
+    target = deepcopy(a)
+    result = iapply(target, ops)
+    assert result is target
+    assert target == b
+
+
+@given(pair=json_diffable_pairs)
+def test_serialized_patches_round_trip(pair):
+    a, b = pair
+    ops, reverse_ops = diff(a, b)
+
+    def reload(operations):
+        parsed = json.loads(to_json(operations))
+        return [{**op, "path": Pointer.from_str(op["path"])} for op in parsed]
+
+    assert apply(a, reload(ops)) == b
+    assert apply(b, reload(reverse_ops)) == a
+
+
+def test_mixed_kind_roots_are_a_known_limitation():
+    """Diffing documents of different top-level kinds yields a
+    whole-document replace at the root, which apply cannot execute.
+
+    Pinned so the limitation is explicit (and so a future fix has to
+    update this test deliberately). See docs/guide/gotchas.md.
+    """
+    ops, reverse_ops = diff([], {})
+    assert ops == [{"op": "replace", "path": Pointer(), "value": {}}]
+    assert reverse_ops == [{"op": "replace", "path": Pointer(), "value": []}]
+    with pytest.raises(AttributeError):
+        apply([], ops)
+
+
+# The empty pointer is excluded: patchdiff renders the root pointer as
+# "/", which parses back as a pointer to the "" key (RFC 6901 renders
+# the root as ""). Root pointers only occur in whole-document replaces,
+# which cannot be applied anyway.
+@given(tokens=st.lists(st.text(), min_size=1, max_size=5))
+def test_pointer_string_round_trip(tokens):
+    ptr = Pointer(tokens)
+    assert Pointer.from_str(str(ptr)) == ptr
+
+
+@given(token=st.text())
+def test_escape_round_trip(token):
+    assert unescape(escape(token)) == token

--- a/tests/test_rfc6902_corpus.py
+++ b/tests/test_rfc6902_corpus.py
@@ -1,0 +1,79 @@
+"""Run the json-patch-tests conformance corpus against patchdiff.
+
+The JSON files in tests/rfc6902/ are vendored verbatim from
+https://github.com/json-patch/json-patch-tests (retrieved 2026-07-10),
+the community conformance suite for RFC 6902 implementations.
+
+Patchdiff deliberately implements a subset-plus-extensions of RFC 6902
+(see docs/guide/gotchas.md), so cases that exercise behavior outside
+that subset are skipped with an explicit reason rather than silently
+dropped:
+
+* ``move``, ``copy`` and ``test`` operations are not implemented.
+* Operations on the document root (path ``""``) are not supported;
+  patches always address a location *inside* a container.
+* Invalid-patch cases (the corpus' ``error`` records) are skipped
+  wholesale: patchdiff does not validate patches, it applies trusted
+  patches produced by ``diff()``/``produce()``, and what it raises for
+  malformed input is not part of its contract.
+
+Every remaining case must pass exactly: paths are parsed from their
+JSON pointer string form with ``Pointer.from_str``, applied with
+``apply``, and compared against the corpus' expected document.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from patchdiff import apply
+from patchdiff.pointer import Pointer
+
+CORPUS_DIR = Path(__file__).parent / "rfc6902"
+
+SUPPORTED_OPS = {"add", "remove", "replace"}
+
+
+def corpus_cases():
+    for filename in ("tests.json", "spec_tests.json"):
+        cases = json.loads((CORPUS_DIR / filename).read_text())
+        for index, case in enumerate(cases):
+            if "patch" not in case:
+                continue  # comment-only records
+            comment = case.get("comment", "")
+            case_id = f"{filename.removesuffix('.json')}-{index:03d}-{comment[:60]}"
+            yield pytest.param(case, id=case_id)
+
+
+def skip_reason(case):
+    if case.get("disabled"):
+        return "disabled in the upstream corpus"
+    if "error" in case:
+        return f"patchdiff does not validate patches ({case['error']!r})"
+    unsupported = {
+        op.get("op") for op in case["patch"] if op.get("op") not in SUPPORTED_OPS
+    }
+    if unsupported:
+        return f"unsupported operation(s): {sorted(unsupported)}"
+    if any(op["path"] == "" for op in case["patch"]):
+        return "operations on the document root are not supported"
+    return None
+
+
+def to_patchdiff_op(op):
+    converted = {"op": op["op"], "path": Pointer.from_str(op["path"])}
+    if "value" in op:
+        converted["value"] = op["value"]
+    return converted
+
+
+@pytest.mark.parametrize("case", list(corpus_cases()))
+def test_corpus_case(case):
+    reason = skip_reason(case)
+    if reason:
+        pytest.skip(reason)
+    ops = [to_patchdiff_op(op) for op in case["patch"]]
+    result = apply(case["doc"], ops)
+    if "expected" in case:
+        assert result == case["expected"]


### PR DESCRIPTION
Track D of the roadmap — test the library's core promises directly instead of spot-checking them. Independent of #50 (both merge cleanly in either order).

## Property tests (new `hypothesis` dev dependency)

Hypothesis generates arbitrary nested structures of dicts, lists, sets, tuples, frozensets and scalars, and verifies:

- **`diff` + `apply` round-trips in both directions** for any same-kind pair of documents.
- **`apply` never mutates its input**; **`iapply` mutates exactly its input** and returns the same object; diff of equal objects is empty.
- **Serialization is lossless for JSON-shaped data**: operations survive `to_json` → `json.loads` → `Pointer.from_str` and still apply correctly, in both directions.
- **Pointer string rendering and RFC 6901 token escaping round-trip.**

## RFC 6902 conformance corpus

`tests/rfc6902/` vendors `tests.json` and `spec_tests.json` verbatim from [json-patch/json-patch-tests](https://github.com/json-patch/json-patch-tests), the community conformance suite. **All 50 applicable cases pass.** The 62 cases outside patchdiff's subset-plus-extensions are skipped with explicit, per-case reasons: `move`/`copy`/`test` operations, operations on the document root, upstream-disabled cases, and invalid-patch validation cases (patchdiff applies trusted patches; it does not validate).

## Bug found and fixed by these tests 🐛

Pointers parsed from strings carry **string tokens**, and `Pointer.evaluate`'s strict parent walk passed them straight into list indexing — so any serialized patch whose path crossed a list could not be applied:

```python
iapply(doc, [{"op": "remove", "path": Pointer.from_str("/baz/0/qux")}])
# TypeError: list indices must be integers or slices, not str
```

This made the documented serialize → parse → apply flow broken for nested-list paths (both the corpus and the JSON round-trip property caught it immediately). `evaluate` now retries string tokens as integer indices for list-like parents — mirroring what `iapply` already did at the leaf — with targeted regression tests for the fix, for non-numeric tokens on lists (`ValueError`), and for traversal into primitives (still `TypeError`).

## Known limitation made explicit

Diffing two documents of **different top-level kinds** (a list against a dict) yields a whole-document `replace` at the root, which `apply`/`iapply` cannot execute. Rather than hiding it, the limitation is pinned in a dedicated test (a future fix must update it deliberately) and documented in the gotchas page. Worth deciding before 1.0.0 whether to support root replaces (e.g. by returning the new root from `apply`) — happy to take that on as a follow-up if you want it.

## Verification

405 passed + 62 documented corpus skips, coverage stays at 100% (including the new `evaluate` branches), ruff check/format pass, docs build stays warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2)_