### PR TITLE
Fix ty failure on master from the #50/#51 merge crossover

### DIFF
--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Hashable, Iterable
+from typing import Any, Hashable, Iterable, cast
 
 from .types import Diffable
 
@@ -86,7 +86,7 @@ class Pointer:
                     # integers (iapply does the same at the leaf).
                     if not hasattr(parent, "append"):
                         raise
-                    cursor = parent[int(key)]
+                    cursor = parent[int(cast("str", key))]
             # The leaf may legitimately not exist (add ops on dicts, list
             # "-" append) so we tolerate lookup failures there — but only
             # when the parent is itself a container we can write into.


### PR DESCRIPTION
One-line fix: master's Typecheck job is currently red. #51 added `int(key)` in `Pointer.evaluate` before #50's typing landed, and each PR's CI ran against a base without the other — merged together, `key` is `Hashable` and `int()` wants something str-ish. Cast at the conversion site; the retry path only runs for string tokens parsed by `Pointer.from_str`.

Verified: `ty check` clean, pointer tests pass, ruff clean. Worth merging ahead of the Track E PRs so their Typecheck runs are meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2

---
_Generated by [Claude Code](https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2)_