### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "patchdiff"
-version = "0.3.12"
+version = "1.0.0"
 description = "Bidirectional, JSON-patch-compliant diffs between Python data structures"
 authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },


### PR DESCRIPTION
This is the 1.0.0 release, closing out the roadmap laid out in #46. It bundles no behavioral changes of its own beyond the version bump — everything below already landed on `master` through the 11 preceding PRs.

## What's in 1.0.0

**Documentation**
- MkDocs + Material docs site with an API reference (mkdocstrings), a guide (diffing, applying patches, `produce()`/drafts, serialization, observ integration), and an internals section covering the list-diff algorithm, proxy design, and pointer semantics (#49)
- Rewritten README pointing at the docs site

**Typing**
- Full modern type hints (PEP 604 unions, builtin generics) checked with `ty` in CI, `Operation` TypedDicts for patch shapes, `py.typed` marker (#49, #50, #52)

**Test hardening**
- Hypothesis-based property tests for round-trip diff/apply/iapply and pointer escaping, plus a vendored RFC 6902 conformance corpus (#51)

**CI & benchmarking**
- Modernized workflows (pinned actions, uv caching, trimmed steps) (#47)
- Noise-robust benchmark guard: interleaved master/PR runs compared by fastest-vs-slowest median rather than a single noisy sample (#48)

**Performance**
- List diff rewritten from an O(m·n) DP table to Myers' O((m+n)·D) algorithm (#53)
- `produce()` hot-path redesign: lazy path recording and epoch-based location memoization instead of eager `Pointer` allocation on every write (#54)
- Micro-optimization passes across diff, apply/iapply, and the produce proxy call paths (#55, #56, #57)

## Benchmarks: 1.0.0 vs 0.3.12

Median times from 3 interleaved local runs per side (`PYTHONHASHSEED=0`, GC disabled), same methodology as CI's benchmark guard.

| Benchmark | 0.3.12 | 1.0.0 | Δ |
|---|---|---|---|
| `list_diff_medium[0.1]` (Myers vs DP) | 340.4 ms | 1.85 ms | **−99.5%** |
| `list_diff_completely_different` | 356.7 ms | 107.8 ms | **−69.8%** |
| `dict_diff_flat_500_keys` | 328.3 µs | 148.8 µs | **−54.7%** |
| `set_diff_1000_elements` | 87.4 µs | 60.7 µs | **−30.5%** |
| `produce_deep_leaf_writes[copy]` | 216.8 µs | 133.5 µs | **−38.4%** |
| `produce_in_place_vs_copy_dict` | 218.8 µs | 188.4 µs | **−13.9%** |
| `diff_dict_many_mutations` | 1.46 ms | 1.19 ms | **−18.3%** |
| `apply_dict_many_ops` | 839.8 µs | 788.1 µs | −6.2% |

The list-diff rewrite dominates: cases with large or scattered edit distance see order-of-magnitude wins, since the DP table's O(m·n) cost no longer applies. A handful of `list_diff_similar_*` benchmarks (many small localized edits already handled well by the prefix/suffix trim) show a mild regression instead — up to +19% — from Myers' bookkeeping overhead on inputs where the old approach had little left to do; this sits within the CI guard's documented noise floor (10–30% run-to-run) and wasn't worth chasing further given the wins elsewhere. Everything else lands within a few percent either way.

## Verification

- `uv run pytest` — 100% coverage
- `uv run ruff check` / `ruff format --check`
- `uv run ty check`
- `mkdocs build` — warning-free

## Next step

Once merged, tag the merge commit `v1.0.0` to trigger the release/publish pipeline (`publish` job in CI, gated on `refs/tags/v*`).


---
_Generated by [Claude Code](https://claude.ai/code/session_016Mu9vEBwU4fQLi8ZgkgdS2)_