### PR TITLE
Modernize for a Python 3.13 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux py39
-            pyversion: "3.9"
-          - name: Linux py310
-            pyversion: "3.10"
-          - name: Linux py311
-            pyversion: "3.11"
-          - name: Linux py312
-            pyversion: "3.12"
           - name: Linux py313
             pyversion: "3.13"
           - name: Linux py314

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ With `in_place=True`, mutations (and patches applied with `iapply`) write straig
 pip install patchdiff  # or: uv add patchdiff
 ```
 
-No dependencies, Python >= 3.9.
+No dependencies, Python >= 3.13.
 
 ## Learn more
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,6 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv add patchdiff
 ```
 
-There are no dependencies. Python 3.9 or newer is required.
+There are no dependencies. Python 3.13 or newer is required.
 
 Next up: the [quick start](quick-start.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Patchdiff 🔍
 
-Based on [rfc6902](https://github.com/chbrown/rfc6902) this library provides a simple API to generate **bi-directional** diffs between composite Python data structures composed out of lists, sets, tuples and dicts. The diffs are JSON-patch compliant, and can optionally be serialized to JSON format. Patchdiff has no dependencies and works on Python 3.9 and up.
+Based on [rfc6902](https://github.com/chbrown/rfc6902) this library provides a simple API to generate **bi-directional** diffs between composite Python data structures composed out of lists, sets, tuples and dicts. The diffs are JSON-patch compliant, and can optionally be serialized to JSON format. Patchdiff has no dependencies and works on Python 3.13 and up.
 
 A single call to [`diff`][patchdiff.diff.diff] gives you the patches in **both directions**:
 

--- a/patchdiff/pointer.py
+++ b/patchdiff/pointer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Hashable, Iterable, cast
+from collections.abc import Hashable, Iterable
+from typing import Any, cast
 
 from .types import Diffable
 
@@ -35,7 +36,7 @@ class Pointer:
         self.tokens = tuple(tokens)
 
     @staticmethod
-    def from_str(path: str) -> "Pointer":
+    def from_str(path: str) -> Pointer:
         """Parse an escaped JSON pointer string (e.g. `"/a/0/b"`) into a Pointer.
 
         All tokens are parsed as strings; numeric list indices become
@@ -104,6 +105,6 @@ class Pointer:
                 cursor = None
         return parent, key, cursor
 
-    def append(self, token: Hashable) -> "Pointer":
+    def append(self, token: Hashable) -> Pointer:
         """Return a new Pointer with `token` appended; self is unchanged."""
         return Pointer((*self.tokens, token))

--- a/patchdiff/produce.py
+++ b/patchdiff/produce.py
@@ -13,8 +13,9 @@ is captured by the snapshot of whatever write re-inserts it later.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Hashable
 from copy import deepcopy
-from typing import Any, Callable, Hashable
+from typing import Any
 from weakref import ref
 
 from .pointer import Pointer
@@ -125,7 +126,7 @@ class PatchRecorder:
         # their memoized _location() results.
         self.epoch: int = 0
 
-    def finalize(self, root: "_Proxy") -> None:
+    def finalize(self, root: _Proxy) -> None:
         """Put the reverse patches in reverse application order and
         detach the root proxy.
 
@@ -236,7 +237,7 @@ class _Proxy:
         self,
         data: Any,
         recorder: PatchRecorder,
-        parent: "_Proxy" | None = None,
+        parent: _Proxy | None = None,
         key: Hashable = None,
     ):
         self._data = data
@@ -340,7 +341,7 @@ class _Proxy:
         self._proxies.clear()
         self._recorder.epoch += 1
 
-    def _in_parent_chain(self, proxy: "_Proxy") -> bool:
+    def _in_parent_chain(self, proxy: _Proxy) -> bool:
         """True when proxy is self or an ancestor of self."""
         node = self
         while node is not None:

--- a/patchdiff/types.py
+++ b/patchdiff/types.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 if TYPE_CHECKING:
     from .pointer import Pointer
 
 # The structures patchdiff diffs and patches. Consumers may also pass
 # duck-typed container look-alikes (e.g. observ reactive proxies).
-Diffable = Union[dict, list, set]
+type Diffable = dict | list | set
 
 
 class AddOperation(TypedDict):
@@ -33,4 +33,4 @@ class ReplaceOperation(TypedDict):
     value: Any
 
 
-Operation = Union[AddOperation, RemoveOperation, ReplaceOperation]
+type Operation = AddOperation | RemoveOperation | ReplaceOperation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Korijn van Golen", email = "korijn@gmail.com" },
     { name = "Berend Klein Haneveld", email = "berendkleinhaneveld@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.13"
 readme = "README.md"
 license = "MIT"
 classifiers = ["Typing :: Typed"]
@@ -42,6 +42,7 @@ extend-select = [
     "N",    # pep8-naming
     "T10",  # flake8-debugger
     "T20",  # flake8-print
+    "UP",   # pyupgrade (keep syntax modern for the supported Python floor)
     "RUF",  # ruff
 ]
 
@@ -56,7 +57,7 @@ include = ["patchdiff"]
 [tool.ty.environment]
 # Match the oldest supported Python version (requires-python), so
 # that the type checker catches use of newer typing features
-python-version = "3.9"
+python-version = "3.13"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Raises the supported Python floor from 3.9 to 3.13 and modernizes the code and docs to match. No behavior changes — the public API, semantics, and 100% coverage are unchanged.

## Version floor

- `pyproject.toml`: `requires-python = ">=3.13"`, and the `ty` environment `python-version` bumped to `3.13` (kept matched to `requires-python`, as its comment intends).
- CI: dropped the 3.9–3.12 entries from the test matrix, keeping 3.13 and 3.14.
- README and docs (`index.md`, `installation.md`) now state Python 3.13 as the minimum.

## Syntax modernization (enabled by the 3.13 floor)

- `types.py`: the `Diffable` and `Operation` aliases now use PEP 695 `type` statements, and unions use PEP 604 `|` instead of `typing.Union`. Both aliases are annotation-only, so this is purely a spelling change.
- `pointer.py` / `produce.py`: `Hashable`, `Iterable`, and `Callable` now come from `collections.abc` instead of the deprecated `typing` aliases; removed the now-redundant string-quoted forward references (`from __future__ import annotations` is already in effect).

## Linting

- Enabled ruff's pyupgrade (`UP`) rule set so outdated syntax is caught against the supported Python floor going forward. The whole tree is already clean under it.

## Verification

- `pytest` with the `--cov-fail-under=100` gate: **411 passed**, 100% coverage, on Python 3.13.
- `ruff check`, `ruff format --check`, and `ty check` all clean.
- `uv build` + `twine check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmQNvz1tx2xncasEyUoVdR)_